### PR TITLE
Feature/flush log cache

### DIFF
--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -49,6 +49,7 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
   private rflib_LogLevel generalLogLevel = rflib_LogLevel.DEBUG;
   private rflib_LogLevel systemDebugLevel = rflib_LogLevel.DEBUG;
   private rflib_LogLevel reportingLogLevel = rflib_LogLevel.WARN;
+  private rflib_LogLevel flushLogStackLevel = rflib_LogLevel.NONE;
   private rflib_LogLevel batchReportingLogLevel = rflib_LogLevel.NONE;
 
 
@@ -107,6 +108,10 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
 
     if (String.isNotBlank(settings.Log_Event_Reporting_Level__c)) {
       logger.setReportingLogLevel(rflib_LogLevel.fromString(settings.Log_Event_Reporting_Level__c));
+    }
+
+    if (String.isNotBlank(settings.Flush_Log_Cache_Level__c)) {
+      logger.setFlushLogCacheLevel(rflib_LogLevel.fromString(settings.Flush_Log_Cache_Level__c));
     }
 
     if (String.isNotBlank(settings.Batched_Log_Event_Reporting_Level__c)) {
@@ -201,6 +206,12 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
     //       when reducing the reporting log level down to INFO. 
     //       See https://github.com/j-fischer/rflib/issues/6 for more details.
     reportingLogLevel = rflib_LogLevel.INFO.encompasses(newLevel) ? newLevel : rflib_LogLevel.INFO;
+  }
+
+  public void setFlushLogCacheLevel(rflib_LogLevel newLevel) {
+    // NOTE: Because this log level is aligned with the reporting log level, the same restrictions 
+    //       apply with respect to the supported levels.
+    flushLogStackLevel = rflib_LogLevel.INFO.encompasses(newLevel) ? newLevel : rflib_LogLevel.INFO;
   }
 
   public void setBatchReportingLogLevel(rflib_LogLevel newLevel) {
@@ -313,6 +324,10 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
       BATCH_EXECUTOR.addEvent(eventToLog);
     } else {
       eventPublisher.publish(eventToLog);
+      
+      if (flushLogStackLevel.encompasses(logLevel)) {
+        LOG_STATEMENTS.clear();
+      }
     }
   }
 

--- a/rflib/main/default/classes/rflib_Logger.cls
+++ b/rflib/main/default/classes/rflib_Logger.cls
@@ -59,9 +59,9 @@ public interface rflib_Logger {
   void setReportingLogLevel(rflib_LogLevel newLevel);
 
   /**
-   * Set the log level for which the log stack should be flushed after a rflib_Log_Event__c Platform Event is 
-   * published. Any log statement that is published and encompassed by set flush stack level, i.e. flush log 
-   * stack level of WARN will match for WARN and ERROR messages, will clear the log stack after the platform 
+   * Set the log level for which the log cache should be flushed after a rflib_Log_Event__c Platform Event is 
+   * published. Any log statement that is published and encompassed by set flush cache level, i.e. flush log 
+   * cache level of WARN will match for WARN and ERROR messages, will clear the log cache after the platform 
    * event is emitted. This means that all historic log statements will be deleted.
    * 
    * rflib_DefaultLogger's default level is NONE.

--- a/rflib/main/default/classes/rflib_Logger.cls
+++ b/rflib/main/default/classes/rflib_Logger.cls
@@ -59,6 +59,20 @@ public interface rflib_Logger {
   void setReportingLogLevel(rflib_LogLevel newLevel);
 
   /**
+   * Set the log level for which the log stack should be flushed after a rflib_Log_Event__c Platform Event is 
+   * published. Any log statement that is published and encompassed by set flush stack level, i.e. flush log 
+   * stack level of WARN will match for WARN and ERROR messages, will clear the log stack after the platform 
+   * event is emitted. This means that all historic log statements will be deleted.
+   * 
+   * rflib_DefaultLogger's default level is NONE.
+   * 
+   * IMPORTANT: The log level cannot be set to a level lower than INFO. 
+   * 
+   * @param  newLevel The new log level to be used to match statements. 
+   */
+  void setFlushLogCacheLevel(rflib_LogLevel newLevel);
+
+  /**
    * Set the log level for which a rflib_Log_Event__c Platform Event should be published asynchronously. 
    * Any log statement that reported and encompassed by set aync reporting level, i.e. async reporting log level of 
    * WARN will match for WARN and ERROR messages, will publish the log event using a `Queueable`.

--- a/rflib/main/default/objects/rflib_Logger_Settings__c/fields/Flush_Log_Cache_Level__c.field-meta.xml
+++ b/rflib/main/default/objects/rflib_Logger_Settings__c/fields/Flush_Log_Cache_Level__c.field-meta.xml
@@ -4,7 +4,7 @@
     <defaultValue>&quot;NONE&quot;</defaultValue>
     <description>Set the log level for which the log cahce should be flushed after a rflib_Log_Event__c Platform Event is published. Any log statement that is published and encompassed by set flush cache level, i.e. flush log cache level of WARN will match for WARN and ERROR messages, will clear the log cache after the platform event is emitted.</description>
     <externalId>false</externalId>
-    <inlineHelpText>Set the log level for which  the log cache should be flushed after a rflib_Log_Event__c Platform Event is pub. Valid values are NONE, INFO, WARN, ERROR, and FATAL. Any statements with a level equal or higher to the one configured here will fire the event.</inlineHelpText>
+    <inlineHelpText>Set the log level for which the log cache should be flushed after a rflib_Log_Event__c Platform Event is published. Valid values are NONE, INFO, WARN, ERROR, and FATAL. Any statements with a level equal or higher to the one configured will fire the event.</inlineHelpText>
     <label>Flush Log Cache Level</label>
     <length>5</length>
     <required>false</required>

--- a/rflib/main/default/objects/rflib_Logger_Settings__c/fields/Flush_Log_Cache_Level__c.field-meta.xml
+++ b/rflib/main/default/objects/rflib_Logger_Settings__c/fields/Flush_Log_Cache_Level__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Flush_Log_Cache_Level__c</fullName>
+    <defaultValue>&quot;NONE&quot;</defaultValue>
+    <description>Set the log level for which the log cahce should be flushed after a rflib_Log_Event__c Platform Event is published. Any log statement that is published and encompassed by set flush cache level, i.e. flush log cache level of WARN will match for WARN and ERROR messages, will clear the log cache after the platform event is emitted.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set the log level for which  the log cache should be flushed after a rflib_Log_Event__c Platform Event is pub. Valid values are NONE, INFO, WARN, ERROR, and FATAL. Any statements with a level equal or higher to the one configured here will fire the event.</inlineHelpText>
+    <label>Flush Log Cache Level</label>
+    <length>5</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
+++ b/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
@@ -289,6 +289,27 @@ public class rflib_DefaultLoggerTest {
     Test.stopTest();
   }
 
+  @IsTest
+  private static void testFlushLogCacheLevel() {
+    rflib_TestLoggerFactory loggerFactory = new rflib_TestLoggerFactory();
+
+    rflib_Logger logger = loggerFactory.createLogger('testFlushLogCacheLevel');
+
+    logger.setReportingLogLevel(rflib_LogLevel.INFO);
+    logger.setFlushLogCacheLevel(rflib_LogLevel.INFO);
+
+    Test.startTest();
+    System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
+    
+    logger.info('message1');
+    System.assert(loggerFactory.eventCapture.containsInAnyMessage('message1'));
+    
+    logger.info('message2');
+    System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('message1'));
+    System.assert(loggerFactory.eventCapture.containsInAnyMessage('message2'));
+    Test.stopTest();
+  }
+
   public class DebugLogCapture implements rflib_DefaultLogger.DebugLogger {
     private final List<String> capturedLogMessages = new List<String>();
     


### PR DESCRIPTION
This change introduces a new custom setting called `Flush Log Cache Level`. It works in association of the reporting log level. If the log event is published and the level of said event is equals or higher to the configured `Flush Log Cache Level` then the log cache will be cleared. 

NOTE: This will NOT effect the Batched Logger because it relies on the cache for the current batching logic. 