### PR TITLE
Feature/request id

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,6 @@
 {
     "orgName": "RFLIB DEV",
     "edition": "Developer",
-    "release": "Preview",
     "features": [],
     "settings": {
         "lightningExperienceSettings": {

--- a/rflib-tf/test/default/classes/rflib_TriggerManagerTest.cls
+++ b/rflib-tf/test/default/classes/rflib_TriggerManagerTest.cls
@@ -225,6 +225,7 @@ private class rflib_TriggerManagerTest {
 
     private static rflib_Log_Event__e createEvent() {
         return new rflib_Log_Event__e(
+            Request_ID__c = 'Some Request ID',
             Log_Level__c = 'INFO',
             Context__c = 'rflib_TriggerManagerTest',
             Log_Messages__c = 'Some log messages'

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -317,6 +317,7 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
     Integer messageSize = messagesAsStr.length();
 
     rflib_Log_Event__e eventToLog = new rflib_Log_Event__e(
+      Request_ID__c = Request.getCurrent().getRequestId(),
       Log_Level__c = logLevel.toString(),
       Context__c = context,
       Log_Messages__c = messageSize < MAX_MESSAGE_SIZE

--- a/rflib/main/default/classes/rflib_SendLogEventEmailAction.cls
+++ b/rflib/main/default/classes/rflib_SendLogEventEmailAction.cls
@@ -38,8 +38,8 @@
 public with sharing class rflib_SendLogEventEmailAction {
     private static final rflib_Logger LOGGER = rflib_LoggerUtil.getFactory().createBatchedLogger('rflib_EmailLogEventHandler');
 
-    private static final String PLAIN_TEXT_MESSAGE = 'A Log Event was created by {0}.\nContext: {1}\nLog Messages: {2}';
-    private static final String HTML_MESSAGE = '<h2>A Log Event was created by {0}.</h2><h3>Context: {1}</h3><p><b>Log Messages:</b> {2}</p>';
+    private static final String PLAIN_TEXT_MESSAGE = 'A Log Event was created by {0}.\Request ID: {1}\nContext: {2}\nLog Messages: {3}';
+    private static final String HTML_MESSAGE = '<h2>A Log Event was created by {0}.</h2><h3>Request ID: {1}</h3><h3>Context: {2}</h3><p><b>Log Messages:</b> {3}</p>';
 
     @TestVisible
     private static Boolean USE_ORG_WIDE_EMAIL_ADDRESS = true;
@@ -120,8 +120,8 @@ public with sharing class rflib_SendLogEventEmailAction {
         }
 
         mail.setSubject('A Log Event Occurred');
-        mail.setPlainTextBody(String.format(PLAIN_TEXT_MESSAGE, new String[] { event.CreatedById, event.Context__c, event.Log_Messages__c  }));
-        mail.setHtmlBody(String.format(HTML_MESSAGE, new String[] { event.CreatedById, event.Context__c, event.Log_Messages__c.replaceAll('(\\r|\\n)+', '<br />')  }));
+        mail.setPlainTextBody(String.format(PLAIN_TEXT_MESSAGE, new String[] { event.CreatedById, event.Request_ID__c, event.Context__c, event.Log_Messages__c  }));
+        mail.setHtmlBody(String.format(HTML_MESSAGE, new String[] { event.CreatedById, event.Request_ID__c, event.Context__c, event.Log_Messages__c.replaceAll('(\\r|\\n)+', '<br />')  }));
 
         Messaging.sendEmail(new Messaging.SingleEmailMessage[] { mail });
     }

--- a/rflib/main/default/lwc/rflibLogEventList/rflibLogEventList.html
+++ b/rflib/main/default/lwc/rflibLogEventList/rflibLogEventList.html
@@ -59,10 +59,13 @@
                     <thead>
                         <tr class="slds-text-heading_label">
                             <th scope="col">
+                                <div class="slds-truncate" title="Date">Date</div>
+                            </th>
+                            <th scope="col">
                                 <div class="slds-truncate" title="Created By">Create By</div>
                             </th>
                             <th scope="col">
-                                <div class="slds-truncate" title="Date">Date</div>
+                                <div class="slds-truncate" title="Request ID">Request ID</div>
                             </th>
                             <th scope="col">
                                 <div class="slds-truncate" title="Level">Level</div>
@@ -70,17 +73,11 @@
                             <th scope="col">
                                 <div class="slds-truncate" title="Context">Context</div>
                             </th>
-                            <th scope="col">
-                                <div class="slds-truncate" title="Message">Message</div>
-                            </th>
                         </tr>
                     </thead>
                     <tbody>
                         <template for:each={eventsToDisplay} for:item="evt">
                             <tr class="clickable" key={evt.Id} data-log-id={evt.Id} onclick={handleLogSelected}>
-                                <td class="slds-truncate">
-                                    <div>{evt.CreatedById}</div>
-                                </td>
                                 <td class="slds-truncate">
                                     <div>
                                         <lightning-formatted-date-time
@@ -95,14 +92,17 @@
                                         </lightning-formatted-date-time>
                                     </div>
                                 </td>
+                                <td class="slds-truncate">
+                                    <div>{evt.CreatedById}</div>
+                                </td>
+                                <td class="slds-truncate">
+                                    <div>{evt.Request_ID__c}</div>
+                                </td>
                                 <td>
                                     <div class="slds-truncate">{evt.Log_Level__c}</div>
                                 </td>
                                 <td>
                                     <div class="slds-truncate">{evt.Context__c}</div>
-                                </td>
-                                <td>
-                                    <div class="slds-truncate" title={evt.Log_Messages__c}>{evt.Log_Messages__c}</div>
                                 </td>
                             </tr>
                         </template>

--- a/rflib/main/default/lwc/rflibLogEventViewer/rflibLogEventViewer.js
+++ b/rflib/main/default/lwc/rflibLogEventViewer/rflibLogEventViewer.js
@@ -50,7 +50,7 @@ export default class LogEventViewer extends LightningElement {
         if (error) {
             let message = 'Unknown error';
             if (Array.isArray(error.body)) {
-                message = error.body.map(e => e.message).join(', ');
+                message = error.body.map((e) => e.message).join(', ');
             } else if (typeof error.body.message === 'string') {
                 message = error.body.message;
             }
@@ -63,7 +63,7 @@ export default class LogEventViewer extends LightningElement {
     }
 
     get title() {
-        return this.logEvent.Log_Level__c + ' - ' + this.logEvent.Context__c;
+        return this.logEvent.Request_ID__c + ' - ' + this.logEvent.Log_Level__c + ' - ' + this.logEvent.Context__c;
     }
 
     get name() {

--- a/rflib/main/default/lwc/rflibLogEventViewer/rflibLogEventViewer.js
+++ b/rflib/main/default/lwc/rflibLogEventViewer/rflibLogEventViewer.js
@@ -90,7 +90,14 @@ export default class LogEventViewer extends LightningElement {
         );
         element.setAttribute(
             'download',
-            this.logEvent.CreatedById + '_' + this.logEvent.Context__c + '_' + this.logEvent.CreatedDate + '.txt'
+            this.logEvent.CreatedById +
+                '_' +
+                this.logEvent.CreatedDate +
+                '_' +
+                this.logEvent.Request_ID__c +
+                '_' +
+                this.logEvent.Context__c +
+                '.txt'
         );
 
         element.style.display = 'none';

--- a/rflib/main/default/objects/rflib_Log_Event__e/fields/Request_ID__c.field-meta.xml
+++ b/rflib/main/default/objects/rflib_Log_Event__e/fields/Request_ID__c.field-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Request_ID__c</fullName>
-    <description>Represents the unique Salesforce Request ID that is assigned to every transaction. This ID can be used to associated the Log Event with Apex Debug Log files and other areas, such as Event Monitoring.</description>
+    <description>Represents the unique Salesforce Request ID that is assigned to every transaction. This ID can be used to associate the Log Event with Apex Debug Log files and other areas such as Event Monitoring.</description>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/rflib/main/default/objects/rflib_Log_Event__e/fields/Request_ID__c.field-meta.xml
+++ b/rflib/main/default/objects/rflib_Log_Event__e/fields/Request_ID__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Request_ID__c</fullName>
+    <description>Represents the unique Salesforce Request ID that is assigned to every transaction. This ID can be used to associated the Log Event with Apex Debug Log files and other areas, such as Event Monitoring.</description>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Request ID</label>
+    <length>255</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/rflib/test/default/classes/rflib_SendLogEventEmailActionTest.cls
+++ b/rflib/test/default/classes/rflib_SendLogEventEmailActionTest.cls
@@ -77,6 +77,7 @@ private class rflib_SendLogEventEmailActionTest {
 
     private static List<rflib_Log_Event__e> createLogEventList() {
         rflib_Log_Event__e ev = new rflib_Log_Event__e(
+            Request_ID__c = 'Some Request ID',
             Context__c = 'Context Foo',
             Log_Messages__c = 'Some messages',
             Log_Level__c = 'ERROR'


### PR DESCRIPTION
Introduced the Salesforce Request ID into the logging framework. The Request ID will now be part of the Log Event and displayed in the search result list, the detailed log message, and the email notification. This will be helpful to link RFLIB logs to Apex Debug logs and Salesforce Event Monitoring.

See https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_class_System_Request.htm#apex_class_System_Request for more details.