### PR TITLE
Support Feature Switch assignments for Public Groups

### DIFF
--- a/rflib-fs/main/default/classes/rflib_FeatureSwitch.cls
+++ b/rflib-fs/main/default/classes/rflib_FeatureSwitch.cls
@@ -136,11 +136,9 @@ public without sharing class rflib_FeatureSwitch {
             return scopedFeatureSwitchValues.get(UserInfo.getUserName());
         }
 
-        if (!directPublicGroupAssociations.isEmpty()) {
-            for (String groupName : directPublicGroupAssociations) {
-                if (scopedFeatureSwitchValues.containsKey(groupName)) {
-                    return scopedFeatureSwitchValues.get(groupName);
-                }
+        for (String groupName : directPublicGroupAssociations) {
+            if (scopedFeatureSwitchValues.containsKey(groupName)) {
+                return scopedFeatureSwitchValues.get(groupName);
             }
         }
 

--- a/rflib-fs/main/default/classes/rflib_FeatureSwitch.cls
+++ b/rflib-fs/main/default/classes/rflib_FeatureSwitch.cls
@@ -55,6 +55,16 @@ public without sharing class rflib_FeatureSwitch {
         private set;
     }
 
+    private static List<String> directPublicGroupAssociations {
+        get {
+            if (directPublicGroupAssociations == null) {
+                directPublicGroupAssociations = getAllDirectPublicGroupAssociationsForUser();
+            }
+            return directPublicGroupAssociations;
+        }
+        private set;
+    }
+
     private static String CACHED_PROFILE_NAME = null;
 
     /**
@@ -126,6 +136,14 @@ public without sharing class rflib_FeatureSwitch {
             return scopedFeatureSwitchValues.get(UserInfo.getUserName());
         }
 
+        if (!directPublicGroupAssociations.isEmpty()) {
+            for (String groupName : directPublicGroupAssociations) {
+                if (scopedFeatureSwitchValues.containsKey(groupName)) {
+                    return scopedFeatureSwitchValues.get(groupName);
+                }
+            }
+        }
+
         String profileName = getProfileName(UserInfo.getProfileId());
         if (scopedFeatureSwitchValues.containsKey(profileName)) {
             return scopedFeatureSwitchValues.get(profileName);
@@ -168,6 +186,20 @@ public without sharing class rflib_FeatureSwitch {
             } else {
                 scopedSwitchSettings.put(featureSwitch.Scope_Name__c, featureSwitch.Turned_On__c);
             }
+        }
+
+        return result;
+    }
+
+    private static List<String> getAllDirectPublicGroupAssociationsForUser() {
+        Id userId = UserInfo.getUserId();
+        List<GroupMember> groupMemberships = [SELECT GroupId, Group.DeveloperName FROM GroupMember WHERE UserOrGroupId= :userId AND Group.Type = 'Regular' ORDER BY Group.DeveloperName ASC];
+
+        LOGGER.debug('Group memberships=' + groupMemberships);
+
+        List<String> result = new List<String>();
+        for (GroupMember gm : groupMemberships) {
+            result.add(gm.Group.DeveloperName);
         }
 
         return result;

--- a/rflib-fs/main/default/objects/rflib_Feature_Switch__mdt/fields/Scope_Type__c.field-meta.xml
+++ b/rflib-fs/main/default/objects/rflib_Feature_Switch__mdt/fields/Scope_Type__c.field-meta.xml
@@ -22,6 +22,11 @@
                 <label>Profile</label>
             </value>
             <value>
+                <fullName>Group</fullName>
+                <default>false</default>
+                <label>Public Group</label>
+            </value>
+            <value>
                 <fullName>User</fullName>
                 <default>false</default>
                 <label>User</label>

--- a/rflib-fs/test/default/classes/rflib_FeatureSwitchTest.cls
+++ b/rflib-fs/test/default/classes/rflib_FeatureSwitchTest.cls
@@ -34,6 +34,7 @@ private class rflib_FeatureSwitchTest {
     private static final String TRIGGER_SWITCH = 'All_Triggers';
 
     @TestVisible private static final String USER_SWITCH = 'FeatureSwitch1';
+    @TestVisible private static final String GROUP_SWITCH = 'FeatureSwitchGroup';
     @TestVisible private static final String PROFILE_SWITCH = 'FeatureSwitch2';
     @TestVisible private static final String GLOBAL_SWITCH = 'FeatureSwitch3';
     @TestVisible private static final String ANOTHER_USER_SWITCH = 'FeatureSwitch4';
@@ -46,6 +47,13 @@ private class rflib_FeatureSwitchTest {
         rflib_FeatureSwitch.featureSwitches = new Map<String,Map<String,Boolean>> {
             USER_SWITCH => new Map<String,Boolean> {
                 'john.smith@rflib.com' => true,
+                'Some_Group' => false,
+                'Standard User' => false,
+                rflib_FeatureSwitch.GLOBAL_SCOPE => false
+            },
+
+            GROUP_SWITCH => new Map<String,Boolean> {
+                'Some_Group' => true,
                 'Standard User' => false,
                 rflib_FeatureSwitch.GLOBAL_SCOPE => false
             },
@@ -65,6 +73,18 @@ private class rflib_FeatureSwitchTest {
         };
 
         rflib_FeatureSwitch.DEFAULT_VALUE = false;
+
+        Group someGroup = new Group(
+            DeveloperName = 'Some_Group',
+            Name = 'Some Group'
+        );
+
+        insert someGroup;
+
+        insert new GroupMember(
+            GroupId = someGroup.Id,
+            UserOrGroupId = USER.Id
+        );
     }
 
     @IsTest
@@ -74,6 +94,16 @@ private class rflib_FeatureSwitchTest {
         System.runAs(USER) {
            System.assertEquals(true, rflib_FeatureSwitch.isTurnedOn(USER_SWITCH));
            System.assertEquals(false, rflib_FeatureSwitch.isTurnedOff(USER_SWITCH));
+        }
+    }
+
+    @IsTest
+    private static void testGroupSwitch() {
+        setup();
+
+        System.runAs(USER) {
+           System.assertEquals(true, rflib_FeatureSwitch.isTurnedOn(GROUP_SWITCH));
+           System.assertEquals(false, rflib_FeatureSwitch.isTurnedOff(GROUP_SWITCH));
         }
     }
 
@@ -123,9 +153,10 @@ private class rflib_FeatureSwitchTest {
 
         System.runAs(USER) {
             Map<String,Boolean> result = rflib_FeatureSwitch.getAllScopedValues();
-            System.assertEquals(4, result.size());
+            System.assertEquals(5, result.size());
 
             System.assertEquals(true, result.get(USER_SWITCH));
+            System.assertEquals(true, result.get(GROUP_SWITCH));
             System.assertEquals(true, result.get(PROFILE_SWITCH));
             System.assertEquals(true, result.get(GLOBAL_SWITCH));
             System.assertEquals(false, result.get(ANOTHER_USER_SWITCH));


### PR DESCRIPTION
Added new feature switch scope type called "Public Group" which allows for overwrites using direct public group memberships. Public Groups only support direct memberships and if a user is assigned to multiple groups, they are evaluated in alphabetical order based on the Developer Name. 