### PR TITLE
Feature/54 added option to cap the creation of log events based on governor limits

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -59,3 +59,4 @@ executecompute
 Numaan
 Mahammad
 apos
+ISNUMBER

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -37,6 +37,8 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
 
   @TestVisible private static final Integer MAX_MESSAGE_SIZE = 131072;
   @TestVisible private static final List<String> LOG_STATEMENTS = new List<String>(); 
+  
+  private static Integer PUBLISHING_COUNTER = 0;
 
   private static rflib_DefaultLogger.BatchPlatformEventExecutor BATCH_EXECUTOR = new rflib_DefaultLogger.BatchPlatformEventExecutor();
 
@@ -411,12 +413,18 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
         ? rflib_GlobalSettings.publishingLimit
         : Limits.getLimitPublishImmediateDML();
         
-      if (Limits.getPublishImmediateDML() >= publishingLimit) {
+      if (Limits.getPublishImmediateDML() == Limits.getLimitPublishImmediateDML()) {
+        System.debug(LoggingLevel.ERROR, 'RFLIB: PublishImmediateDML Governor Limit reached; failed to publish ' + JSON.serialize(event));
+        return;
+      }
+
+      if (PUBLISHING_COUNTER == publishingLimit) {
         System.debug(LoggingLevel.ERROR, 'RFLIB: Publish Immediate DML limit (' + publishingLimit +') reached; failed to publish ' + JSON.serialize(event));
         return;
       }
       
-      Database.SaveResult result = EventBus.publish(event);     
+      Database.SaveResult result = EventBus.publish(event);
+      PUBLISHING_COUNTER++;     
       
       if(!result.isSuccess()) {
         System.debug(LoggingLevel.ERROR, JSON.serialize(result.getErrors()));

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -423,12 +423,27 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
         return;
       }
       
-      Database.SaveResult result = EventBus.publish(event);
+      Database.SaveResult result = EventBus.publish(getUpdatedLogEventIfLimitIsReached(event, publishingLimit));
       PUBLISHING_COUNTER++;     
       
       if(!result.isSuccess()) {
         System.debug(LoggingLevel.ERROR, JSON.serialize(result.getErrors()));
       }
+    }
+
+    private rflib_Log_Event__e getUpdatedLogEventIfLimitIsReached(rflib_Log_Event__e logEvent, Integer publishingLimit) {
+      if (PUBLISHING_COUNTER < (publishingLimit - 1)) {
+        return logEvent;
+      }
+
+      String logMessage = '>>>>> RFLIB: Publish Immediate DML limit (' + publishingLimit +') reached; THIS IS THE LAST EVENT FOR THIS TRANSACTION  <<<<<\n\n' + logEvent.Log_Messages__c;
+      Integer messageSize = logMessage.length();
+
+      logEvent.Log_Messages__c = messageSize < MAX_MESSAGE_SIZE
+        ? logMessage 
+        : logMessage.substring(messageSize - MAX_MESSAGE_SIZE);
+
+      return logEvent;
     }
   }
 

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -35,8 +35,6 @@
 @SuppressWarnings('PMD.ClassNamingConventions')
 public without sharing class rflib_DefaultLogger implements rflib_Logger {
 
-  public static Integer PUBLISHING_LIMIT = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
-
   @TestVisible private static final Integer MAX_MESSAGE_SIZE = 131072;
   @TestVisible private static final List<String> LOG_STATEMENTS = new List<String>(); 
 
@@ -409,8 +407,12 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
 
   public class PlatformEventPublisher implements EventPublisher {
     public void publish(rflib_Log_Event__e event) {
-      if (Limits.getPublishImmediateDML() >= PUBLISHING_LIMIT) {
-        System.debug(LoggingLevel.ERROR, 'RFLIB: Publish Immediate DML limit (' + PUBLISHING_LIMIT +') reached; failed to publish ' + JSON.serialize(event));
+      Integer publishingLimit = rflib_GlobalSettings.publishingLimit != null 
+        ? rflib_GlobalSettings.publishingLimit
+        : Limits.getLimitPublishImmediateDML();
+        
+      if (Limits.getPublishImmediateDML() >= publishingLimit) {
+        System.debug(LoggingLevel.ERROR, 'RFLIB: Publish Immediate DML limit (' + publishingLimit +') reached; failed to publish ' + JSON.serialize(event));
       }
       
       Database.SaveResult result = EventBus.publish(event);     

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -436,12 +436,16 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
         return logEvent;
       }
 
-      String logMessage = '>>>>> RFLIB: Publish Immediate DML limit (' + publishingLimit +') reached; THIS IS THE LAST EVENT FOR THIS TRANSACTION  <<<<<\n\n' + logEvent.Log_Messages__c;
-      Integer messageSize = logMessage.length();
+      String rflibInfoMessage = '>>>>> RFLIB: Publish Immediate DML limit (' + publishingLimit +') reached; THIS IS THE LAST EVENT FOR THIS TRANSACTION  <<<<<\n\n';
+      Integer rflibInfoMessageSize = rflibInfoMessage.length();
 
-      logEvent.Log_Messages__c = messageSize < MAX_MESSAGE_SIZE
-        ? logMessage 
-        : logMessage.substring(messageSize - MAX_MESSAGE_SIZE);
+      Integer expectedMessageSize = logEvent.Log_Messages__c.length() + rflibInfoMessageSize;
+
+      String logMessage = expectedMessageSize < MAX_MESSAGE_SIZE
+        ? rflibInfoMessage + logEvent.Log_Messages__c 
+        : rflibInfoMessage + logEvent.Log_Messages__c.substring(expectedMessageSize - MAX_MESSAGE_SIZE);
+
+      logEvent.Log_Messages__c = logMessage;
 
       return logEvent;
     }

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -413,6 +413,7 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
         
       if (Limits.getPublishImmediateDML() >= publishingLimit) {
         System.debug(LoggingLevel.ERROR, 'RFLIB: Publish Immediate DML limit (' + publishingLimit +') reached; failed to publish ' + JSON.serialize(event));
+        return;
       }
       
       Database.SaveResult result = EventBus.publish(event);     

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -35,6 +35,8 @@
 @SuppressWarnings('PMD.ClassNamingConventions')
 public without sharing class rflib_DefaultLogger implements rflib_Logger {
 
+  public static Integer PUBLISHING_LIMIT = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
+
   @TestVisible private static final Integer MAX_MESSAGE_SIZE = 131072;
   @TestVisible private static final List<String> LOG_STATEMENTS = new List<String>(); 
 
@@ -407,7 +409,12 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
 
   public class PlatformEventPublisher implements EventPublisher {
     public void publish(rflib_Log_Event__e event) {
+      if (Limits.getPublishImmediateDML() >= PUBLISHING_LIMIT) {
+        System.debug(LoggingLevel.ERROR, 'RFLIB: Publish Immediate DML limit (' + PUBLISHING_LIMIT +') reached; failed to publish ' + JSON.serialize(event));
+      }
+      
       Database.SaveResult result = EventBus.publish(event);     
+      
       if(!result.isSuccess()) {
         System.debug(LoggingLevel.ERROR, JSON.serialize(result.getErrors()));
       }

--- a/rflib/main/default/classes/rflib_GlobalSettings.cls
+++ b/rflib/main/default/classes/rflib_GlobalSettings.cls
@@ -61,4 +61,13 @@ public with sharing class rflib_GlobalSettings {
 
         return SETTINGS.get(name);
     }
+
+    public static void overridePublishingLimit(Integer newLimit) {
+        if (newLimit < 0 || newLimit > Limits.getPublishImmediateDML()) {
+            throw new rflib_InvalidArgumentException('newLimit', 'value provided (' + newLimit + ') is less than 0 or higher than allowed limit: ' + Limits.getPublishImmediateDML());
+        }
+
+        String newLimitStr = newLimit != null ? String.valueOf(newLimit) : rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c;
+        SETTINGS.put('Publish_Platform_Event_Transaction_Limit', newLimitStr);
+    }
 }

--- a/rflib/main/default/classes/rflib_GlobalSettings.cls
+++ b/rflib/main/default/classes/rflib_GlobalSettings.cls
@@ -63,7 +63,7 @@ public with sharing class rflib_GlobalSettings {
     }
 
     public static void overridePublishingLimit(Integer newLimit) {
-        if (newLimit < 0 || newLimit > Limits.getPublishImmediateDML()) {
+        if (newLimit < 0 || newLimit > Limits.getLimitPublishImmediateDML()) {
             throw new rflib_InvalidArgumentException('newLimit', 'value provided (' + newLimit + ') is less than 0 or higher than allowed limit: ' + Limits.getPublishImmediateDML());
         }
 

--- a/rflib/main/default/classes/rflib_GlobalSettings.cls
+++ b/rflib/main/default/classes/rflib_GlobalSettings.cls
@@ -40,6 +40,13 @@ public with sharing class rflib_GlobalSettings {
         }
     }
 
+    public static Integer publishingLimit {
+        get {
+            String val = getSetting('Publish_Platform_Event_Transaction_Limit');
+            return val == null ? null : Integer.valueOf(val);
+        }
+    }
+
     private static final Map<String, String> SETTINGS = new Map<String, String>();
 
     @SuppressWarnings('PMD.EmptyStatementBlock')

--- a/rflib/main/default/classes/rflib_InvalidArgumentException.cls
+++ b/rflib/main/default/classes/rflib_InvalidArgumentException.cls
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Johannes Fischer <fischer.jh@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name "RFLIB", the name of the copyright holder, nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+@SuppressWarnings('PMD.ClassNamingConventions')
+public class rflib_InvalidArgumentException extends Exception {
+    
+    public rflib_InvalidArgumentException(String argumentName, String errorMessage) {
+        this('Argument "' + argumentName + '" is invalid. Details: ' + errorMessage);
+    }
+}

--- a/rflib/main/default/classes/rflib_InvalidArgumentException.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_InvalidArgumentException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rflib/main/default/customMetadata/rflib_Global_Setting.Publish_Platform_Event_Transaction_Limit.md-meta.xml
+++ b/rflib/main/default/customMetadata/rflib_Global_Setting.Publish_Platform_Event_Transaction_Limit.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Publish Platform Event Transaction Limit</label>
+    <protected>false</protected>
+    <values>
+        <field>Value__c</field>
+        <value xsi:type="xsd:string">150</value>
+    </values>
+</CustomMetadata>

--- a/rflib/main/default/objects/rflib_Global_Setting__mdt/validationRules/Publish_Limit_Must_Be_Number.validationRule-meta.xml
+++ b/rflib/main/default/objects/rflib_Global_Setting__mdt/validationRules/Publish_Limit_Must_Be_Number.validationRule-meta.xml
@@ -4,8 +4,10 @@
     <active>true</active>
     <description>Publish_Platform_Event_Transaction_Limit value must be a number.</description>
     <errorConditionFormula>DeveloperName = &apos;Publish_Platform_Event_Transaction_Limit&apos; &amp;&amp; 
-ISNUMBER( Value__c ) &amp;&amp;
-VALUE( Value__c ) &gt; 0</errorConditionFormula>
+OR(
+  NOT(ISNUMBER( Value__c )),
+  VALUE( Value__c ) &lt;= 0
+)</errorConditionFormula>
     <errorDisplayField>Value__c</errorDisplayField>
     <errorMessage>The value for the Publish Platform Event Transaction Limit setting must be a number larger than 0.</errorMessage>
 </ValidationRule>

--- a/rflib/main/default/objects/rflib_Global_Setting__mdt/validationRules/Publish_Limit_Must_Be_Number.validationRule-meta.xml
+++ b/rflib/main/default/objects/rflib_Global_Setting__mdt/validationRules/Publish_Limit_Must_Be_Number.validationRule-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Publish_Limit_Must_Be_Number</fullName>
+    <active>true</active>
+    <description>Publish_Platform_Event_Transaction_Limit value must be a number.</description>
+    <errorConditionFormula>DeveloperName = &apos;Publish_Platform_Event_Transaction_Limit&apos; &amp;&amp; 
+ISNUMBER( Value__c ) &amp;&amp;
+VALUE( Value__c ) &gt; 0</errorConditionFormula>
+    <errorDisplayField>Value__c</errorDisplayField>
+    <errorMessage>The value for the Publish Platform Event Transaction Limit setting must be a number larger than 0.</errorMessage>
+</ValidationRule>

--- a/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
+++ b/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
@@ -250,6 +250,29 @@ public class rflib_DefaultLoggerTest {
     logger.info('This is a test message');
 
     Test.startTest();
+    System.assertEquals(0, Limits.getPublishImmediateDML());
+    logger.reportLogs();
+    System.assertEquals(1, Limits.getPublishImmediateDML());
+    Test.stopTest();
+  }
+
+  @IsTest
+  private static void testSyncPlatformEventPublisher_publishingLimits() {
+    rflib_Logger logger = new rflib_DefaultLogger(
+      new rflib_DefaultLogger.PlatformEventPublisher(), 
+      new rflib_DefaultLogger.SystemDebugLogger(), 
+      'testSyncPlatformEventPublisher'
+    );
+
+    logger.info('This is a test message');
+
+    Test.startTest();
+    System.assertEquals(0, Limits.getPublishImmediateDML());
+    logger.reportLogs();
+    System.assertEquals(1, Limits.getPublishImmediateDML());
+    
+    rflib_GlobalSettings.overridePublishingLimit(1);
+
     logger.reportLogs();
     System.assertEquals(1, Limits.getPublishImmediateDML());
     Test.stopTest();

--- a/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
+++ b/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
@@ -279,6 +279,29 @@ public class rflib_DefaultLoggerTest {
   }
 
   @IsTest
+  private static void testSyncPlatformEventPublisher_governorLimitReached() {
+    rflib_Logger logger = new rflib_DefaultLogger(
+      new rflib_DefaultLogger.PlatformEventPublisher(), 
+      new rflib_DefaultLogger.SystemDebugLogger(), 
+      'testSyncPlatformEventPublisher'
+    );
+
+    logger.info('This is a test message');
+
+    rflib_GlobalSettings.overridePublishingLimit(null);
+
+    Test.startTest();
+    System.assertEquals(0, Limits.getPublishImmediateDML());
+    Integer i, count = Limits.getLimitPublishImmediateDML() + 1;
+    for (i = 0; i < count; i++) {
+      logger.reportLogs();
+    }
+
+    System.assertEquals(Limits.getLimitPublishImmediateDML(), Limits.getPublishImmediateDML());
+    Test.stopTest();
+  }
+
+  @IsTest
   private static void testBatchPlatformEventPublisher() {
     rflib_Logger logger = new rflib_DefaultLogger(
       new rflib_DefaultLogger.BatchPlatformEventPublisher(), 

--- a/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
+++ b/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
@@ -53,8 +53,8 @@ private class rflib_GlobalSettingsTest {
         Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
 
         Test.startTest();
-        rflib_GlobalSettings.overridePublishingLimit(0);
-        System.assertEquals(0, rflib_GlobalSettings.publishingLimit);
+        rflib_GlobalSettings.overridePublishingLimit(5);
+        System.assertEquals(5, rflib_GlobalSettings.publishingLimit);
         Test.stopTest();
     }
 
@@ -80,7 +80,7 @@ private class rflib_GlobalSettingsTest {
         System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimit);
         
         try {
-            rflib_GlobalSettings.overridePublishingLimit(Limits.getPublishImmediateDML() + 1);
+            rflib_GlobalSettings.overridePublishingLimit(Limits.getLimitPublishImmediateDML() + 1);
             System.assert(false, 'Expected rflib_InvalidArgumentException has not been thrown');
         } catch (rflib_InvalidArgumentException ex) {
             System.assert(ex.getMessage().contains('is less than 0 or higher than allowed limit'));

--- a/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
+++ b/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
@@ -38,4 +38,13 @@ private class rflib_GlobalSettingsTest {
         System.assertEquals(expectedValue, rflib_GlobalSettings.traceIdHeaderName);
         Test.stopTest();
     }
+
+    @IsTest
+    static void testPublishingLimit() {
+        Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
+
+        Test.startTest();
+        System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimit);
+        Test.stopTest();
+    }
 }

--- a/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
+++ b/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
@@ -47,4 +47,44 @@ private class rflib_GlobalSettingsTest {
         System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimit);
         Test.stopTest();
     }
+
+    @IsTest
+    static void testOverridePublishingLimit_Success() {
+        Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
+
+        Test.startTest();
+        rflib_GlobalSettings.overridePublishingLimit(0);
+        System.assertEquals(0, rflib_GlobalSettings.publishingLimit);
+        Test.stopTest();
+    }
+
+
+    @IsTest
+    static void testOverridePublishingLimit_NullValue() {
+        Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
+
+        Test.startTest();
+        rflib_GlobalSettings.overridePublishingLimit(0);
+        System.assertEquals(0, rflib_GlobalSettings.publishingLimit);
+        
+        rflib_GlobalSettings.overridePublishingLimit(null);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimit);
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testOverridePublishingLimit_ValueExceedsLimit() {
+        Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
+
+        Test.startTest();
+        System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimit);
+        
+        try {
+            rflib_GlobalSettings.overridePublishingLimit(Limits.getPublishImmediateDML() + 1);
+            System.assert(false, 'Expected rflib_InvalidArgumentException has not been thrown');
+        } catch (rflib_InvalidArgumentException ex) {
+            System.assert(ex.getMessage().contains('is less than 0 or higher than allowed limit'));
+        }
+        Test.stopTest();
+    }
 }


### PR DESCRIPTION
Added Global Config record to limit the amount of Platform Events that RFLIB will publish during a transaction