### PR TITLE
Feature/email notification enhancements

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -8,7 +8,7 @@ package.xml
 **/appMenus/**
 **/applictions/standard__*
 
-rflib/main/default/apexEmailNotifications
+rflib/main/default/apexEmailNotifications/apexEmailNotifications.notifications-meta.xml
 rflib/main/default/permissionsets/Functions.permissionset-meta.xml
 
 # LWC configuration files

--- a/rflib/main/default/classes/rflib_ApplicationEventArchiver.cls
+++ b/rflib/main/default/classes/rflib_ApplicationEventArchiver.cls
@@ -43,9 +43,6 @@ public inherited sharing class rflib_ApplicationEventArchiver implements Schedul
     @TestVisible
     private static rflib_ApplicationEventService APPLICATION_EVENT_SERVICE = new rflib_DefaultApplicationEventService();
 
-    @TestVisible
-    private static rflib_Global_Setting__mdt APPLICATION_EVENT_RETAIN_X_DAYS  = rflib_Global_Setting__mdt.getInstance('Application_Event_Retain_X_Days');
-
     /**
      * @description Move records from the `rflib_Application_Event__c` object to the `rflib_Application_Event_Archive__b` Big Object archive.
      * @param  ctx ctx The `SchedulableContext`, which is not used.
@@ -54,8 +51,7 @@ public inherited sharing class rflib_ApplicationEventArchiver implements Schedul
         try {
             LOGGER.info('execute() invoked');
 
-            Integer retainXNumberOfDays = Integer.valueOf(APPLICATION_EVENT_RETAIN_X_DAYS.Value__c);
-            Date threshold = TODAY.addDays(retainXNumberOfDays * (-1));
+            Date threshold = TODAY.addDays(rflib_GlobalSettings.daysToRetainApplicationEventsOrDefault * (-1));
 
             List<rflib_Application_Event__c> applicationEvents = [
                 SELECT Id, Created_By_ID__c, Occurred_On__c, Event_Name__c, Related_Record_ID__c, Additional_Details__c

--- a/rflib/main/default/classes/rflib_DefaultApplicationEventService.cls
+++ b/rflib/main/default/classes/rflib_DefaultApplicationEventService.cls
@@ -71,8 +71,8 @@ public inherited sharing class rflib_DefaultApplicationEventService implements r
     public void publishApplicationEvents(List<rflib_ApplicationEventDetails> applicationEvents) {
         LOGGER.debug('publishApplicationEvents({0})', new Object[] { applicationEvents });
 
-        Integer publishingLimit = rflib_GlobalSettings.publishingLimit != null 
-            ? rflib_GlobalSettings.publishingLimit
+        Integer publishingLimitOrDefault = rflib_GlobalSettings.publishingLimitOrDefault != null 
+            ? rflib_GlobalSettings.publishingLimitOrDefault
             : Limits.getLimitPublishImmediateDML();
             
         if (Limits.getPublishImmediateDML() == Limits.getLimitPublishImmediateDML()) {
@@ -80,8 +80,8 @@ public inherited sharing class rflib_DefaultApplicationEventService implements r
             return;
         }
 
-        if (EVENT_PUBLISHER.getPublishingCounter() == publishingLimit) {
-            System.debug(LoggingLevel.ERROR, 'RFLIB: Publish Immediate DML limit (' + publishingLimit +') reached; failed to publish application events: ');
+        if (EVENT_PUBLISHER.getPublishingCounter() == publishingLimitOrDefault) {
+            System.debug(LoggingLevel.ERROR, 'RFLIB: Publish Immediate DML limit (' + publishingLimitOrDefault +') reached; failed to publish application events: ');
             return;
         }
 
@@ -103,7 +103,7 @@ public inherited sharing class rflib_DefaultApplicationEventService implements r
             ));
         }
 
-        if (EVENT_PUBLISHER.getPublishingCounter() == (publishingLimit - 1)) {
+        if (EVENT_PUBLISHER.getPublishingCounter() == (publishingLimitOrDefault - 1)) {
             eventsToPublish.add(new rflib_Application_Event_Occurred_Event__e(
                 Event_Name__c = 'application-event-publishing-limit-reached',
                 Occurred_On__c = occurredOn,

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -455,8 +455,8 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
       
       List<rflib_Log_Event__e> eventsToPublish = new List<rflib_Log_Event__e>((List<rflib_Log_Event__e>) events);
 
-      Integer publishingLimit = rflib_GlobalSettings.publishingLimit != null 
-        ? rflib_GlobalSettings.publishingLimit
+      Integer publishingLimitOrDefault = rflib_GlobalSettings.publishingLimitOrDefault != null 
+        ? rflib_GlobalSettings.publishingLimitOrDefault
         : Limits.getLimitPublishImmediateDML();
         
       if (Limits.getPublishImmediateDML() == Limits.getLimitPublishImmediateDML()) {
@@ -464,12 +464,12 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
         return null;
       }
 
-      if (eventBusPublisher.getPublishingCounter() == publishingLimit) {
-        System.debug(LoggingLevel.ERROR, 'RFLIB: Publish Immediate DML limit (' + publishingLimit +') reached; failed to publish ' + JSON.serialize(events));
+      if (eventBusPublisher.getPublishingCounter() == publishingLimitOrDefault) {
+        System.debug(LoggingLevel.ERROR, 'RFLIB: Publish Immediate DML limit (' + publishingLimitOrDefault +') reached; failed to publish ' + JSON.serialize(events));
         return null;
       }
       
-      List<Database.SaveResult> results = eventBusPublisher.publish(addLogEventIfLimitIsReached(eventsToPublish, publishingLimit));
+      List<Database.SaveResult> results = eventBusPublisher.publish(addLogEventIfLimitIsReached(eventsToPublish, publishingLimitOrDefault));
       
       for (Database.SaveResult result : results) {
         if(!result.isSuccess()) {
@@ -480,12 +480,12 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
       return results;
     }
 
-    private List<rflib_Log_Event__e> addLogEventIfLimitIsReached(List<rflib_Log_Event__e> logEvents, Integer publishingLimit) {
-      if (eventBusPublisher.getPublishingCounter() < (publishingLimit - 1)) {
+    private List<rflib_Log_Event__e> addLogEventIfLimitIsReached(List<rflib_Log_Event__e> logEvents, Integer publishingLimitOrDefault) {
+      if (eventBusPublisher.getPublishingCounter() < (publishingLimitOrDefault - 1)) {
         return logEvents;
       }
 
-      String rflibInfoMessage = '>>>>> RFLIB: Publish Immediate DML limit (' + publishingLimit +') reached; THIS IS THE LAST EVENT FOR THIS TRANSACTION  <<<<<\n\n';
+      String rflibInfoMessage = '>>>>> RFLIB: Publish Immediate DML limit (' + publishingLimitOrDefault +') reached; THIS IS THE LAST EVENT FOR THIS TRANSACTION  <<<<<\n\n';
       String requestId = Request.getCurrent().getRequestId();
       if (requestId == null) {
         requestId = 'NULL';

--- a/rflib/main/default/classes/rflib_GlobalSettings.cls
+++ b/rflib/main/default/classes/rflib_GlobalSettings.cls
@@ -69,10 +69,10 @@ public with sharing class rflib_GlobalSettings {
         }
     }
     
-    public static Boolean useOrgWideEmailAddress {
+    public static Boolean useDefaultWorkflowUserForLogEventsOrDefault {
         get {
-            String val = getSetting('Use_Org_Wide_Email_Address');
-            return String.isBlank(val) ? true : Boolean.valueOf(val);
+            String val = getSetting('Use_Default_Workflow_User_for_Log_Events');
+            return String.isBlank(val) ? false : Boolean.valueOf(val);
         }
     }
 

--- a/rflib/main/default/classes/rflib_GlobalSettings.cls
+++ b/rflib/main/default/classes/rflib_GlobalSettings.cls
@@ -31,19 +31,47 @@
  * @group Common
  * @description Provides values for any rflib related global settings.
  */ 
- @SuppressWarnings('PMD.ClassNamingConventions')
+@SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class rflib_GlobalSettings {
+    
+    public static Integer daysToRetainApplicationEvents {
+        get {
+            String val = getSetting('Application_Event_Retain_X_Days');
+            return val == null ? null : Integer.valueOf(val);
+        }
+    }
+    
+    public static Integer archiveLogQueryLimit {
+        get {
+            String val = getSetting('Archive_Log_Query_Limit');
+            return val == null ? null : Integer.valueOf(val);
+        }
+    }
 
+    public static Boolean useRestQueryModeForPermissionRetrieval {
+        get {
+            String val = getSetting('Permissions_Explorer_REST_API_Enabled');
+            return val == null ? false : Boolean.valueOf(val);
+        }
+    }
+        
+    public static Integer publishingLimit {
+        get {
+            String val = getSetting('Publish_Platform_Event_Transaction_Limit');
+            return val == null ? null : Integer.valueOf(val);
+        }
+    }
+    
     public static String traceIdHeaderName {
         get {
             return getSetting('Trace_ID_Header_Name');
         }
     }
-
-    public static Integer publishingLimit {
+    
+    public static Boolean useOrgWideEmailAddress {
         get {
-            String val = getSetting('Publish_Platform_Event_Transaction_Limit');
-            return val == null ? null : Integer.valueOf(val);
+            String val = getSetting('Use_Org_Wide_Email_Address');
+            return val == null ? true : Boolean.valueOf(val);
         }
     }
 

--- a/rflib/main/default/classes/rflib_GlobalSettings.cls
+++ b/rflib/main/default/classes/rflib_GlobalSettings.cls
@@ -34,47 +34,49 @@
 @SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class rflib_GlobalSettings {
     
-    public static Integer daysToRetainApplicationEvents {
+    public static Integer daysToRetainApplicationEventsOrDefault {
         get {
             String val = getSetting('Application_Event_Retain_X_Days');
-            return val == null ? null : Integer.valueOf(val);
+            return String.isBlank(val) ? 45 : Integer.valueOf(val);
         }
     }
     
-    public static Integer archiveLogQueryLimit {
+    public static Integer archiveLogQueryLimitOrDefault {
         get {
             String val = getSetting('Archive_Log_Query_Limit');
-            return val == null ? null : Integer.valueOf(val);
+            return String.isBlank(val) ? 50000 : Integer.valueOf(val);
         }
     }
 
-    public static Boolean useRestQueryModeForPermissionRetrieval {
+    public static Boolean useRestQueryModeForPermissionRetrievalOrDefault {
         get {
             String val = getSetting('Permissions_Explorer_REST_API_Enabled');
-            return val == null ? false : Boolean.valueOf(val);
+            return String.isBlank(val) ? false : Boolean.valueOf(val);
         }
     }
         
-    public static Integer publishingLimit {
+    public static Integer publishingLimitOrDefault {
         get {
             String val = getSetting('Publish_Platform_Event_Transaction_Limit');
-            return val == null ? null : Integer.valueOf(val);
+            return String.isBlank(val) ? 150 : Integer.valueOf(val);
         }
     }
     
-    public static String traceIdHeaderName {
+    public static String traceIdHeaderNameOrDefault {
         get {
-            return getSetting('Trace_ID_Header_Name');
+            String val = getSetting('Trace_ID_Header_Name');
+            return String.isBlank(val) ? 'X-Trace-ID' : val;
         }
     }
     
     public static Boolean useOrgWideEmailAddress {
         get {
             String val = getSetting('Use_Org_Wide_Email_Address');
-            return val == null ? true : Boolean.valueOf(val);
+            return String.isBlank(val) ? true : Boolean.valueOf(val);
         }
     }
 
+    @TestVisible
     private static final Map<String, String> SETTINGS = new Map<String, String>();
 
     @SuppressWarnings('PMD.EmptyStatementBlock')
@@ -90,7 +92,7 @@ public with sharing class rflib_GlobalSettings {
         return SETTINGS.get(name);
     }
 
-    public static void overridePublishingLimit(Integer newLimit) {
+    public static void overridePublishingLimitOrDefault(Integer newLimit) {
         if (newLimit < 0 || newLimit > Limits.getLimitPublishImmediateDML()) {
             throw new rflib_InvalidArgumentException('newLimit', 'value provided (' + newLimit + ') is less than 0 or higher than allowed limit: ' + Limits.getPublishImmediateDML());
         }

--- a/rflib/main/default/classes/rflib_HttpRequest.cls
+++ b/rflib/main/default/classes/rflib_HttpRequest.cls
@@ -59,7 +59,7 @@ public with sharing class rflib_HttpRequest {
         try {
             LOGGER.info('Sending request: {0} with body: {1}', new String[] { delegatee.toString(), delegatee.getBody() } );
     
-            delegatee.setHeader(rflib_GlobalSettings.traceIdHeaderName, rflib_TraceId.value);
+            delegatee.setHeader(rflib_GlobalSettings.traceIdHeaderNameOrDefault, rflib_TraceId.value);
     
             Http http = new Http();
             HttpResponse response = http.send(delegatee);

--- a/rflib/main/default/classes/rflib_LogArchiveController.cls
+++ b/rflib/main/default/classes/rflib_LogArchiveController.cls
@@ -31,7 +31,7 @@ public with sharing class rflib_LogArchiveController {
     
     private static final rflib_Logger LOGGER = rflib_LoggerUtil.getFactory().createLogger('rflib_LogArchiveController');
 
-    private static final Integer ARCHIVE_LOG_QUERY_LIMIT = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Archive_Log_Query_Limit').Value__c);
+    private static final Integer ARCHIVE_LOG_QUERY_LIMIT = rflib_GlobalSettings.archiveLogQueryLimitOrDefault;
     
     @TestVisible
     private static ILogArchiveQueryLocator QUERY_LOCATOR = new DefaultLogArchiveQueryLocator();

--- a/rflib/main/default/classes/rflib_PermissionsExplorerController.cls
+++ b/rflib/main/default/classes/rflib_PermissionsExplorerController.cls
@@ -50,15 +50,13 @@ public with sharing class rflib_PermissionsExplorerController {
     @TestVisible private static final String FLS_ORDER = ' ORDER BY Parent.Profile.Name, Parent.Label, SobjectType, Field'; 
     @TestVisible private static final String OBJ_ORDER = ' ORDER BY Parent.Profile.Name, Parent.Label, SobjectType'; 
 
-    @TestVisible private static rflib_Global_Setting__mdt queryMode = rflib_Global_Setting__mdt.getInstance('Permissions_Explorer_REST_API_Enabled');
-
     @TestVisible private static rflib_QueryExecutor queryExecutor  = new rflib_DatabaseQueryExecutor();
 
     @AuraEnabled(cacheable = true)
     public static QueryResult getFieldLevelSecurityForAllProfiles(String servicePath){
         try {
             LOGGER.info('getFieldLevelSecurityForAllProfiles: servicePath=' + servicePath);
-            return useRestQueryModel() ? 
+            return shouldUseRestQueryModel() ? 
                 queryFieldPermissionsRest(servicePath, FLS_SEARCH_TYPE, PROFILE_QUERY_CONDITION) : 
                 queryFieldPermissionsApex(FLS_SEARCH_TYPE, PROFILE_QUERY_CONDITION);
         } catch (Exception ex) {
@@ -71,7 +69,7 @@ public with sharing class rflib_PermissionsExplorerController {
     public static QueryResult getFieldLevelSecurityForAllPermissionSets(String servicePath) {
         try {
             LOGGER.info('getFieldLevelSecurityForAllPermissionSets: servicePath=' + servicePath);
-            return useRestQueryModel() ? 
+            return shouldUseRestQueryModel() ? 
                 queryFieldPermissionsRest(servicePath, FLS_SEARCH_TYPE, PERMISSION_SET_QUERY_CONDITION) : 
                 queryFieldPermissionsApex(FLS_SEARCH_TYPE, PERMISSION_SET_QUERY_CONDITION);
         } catch (Exception ex) {
@@ -84,7 +82,7 @@ public with sharing class rflib_PermissionsExplorerController {
     public static QueryResult getObjectLevelSecurityForAllProfiles(String servicePath){
         try {
             LOGGER.info('getObjectLevelSecurityForAllProfiles: servicePath=' + servicePath);
-            return useRestQueryModel() ? 
+            return shouldUseRestQueryModel() ? 
                 queryFieldPermissionsRest(servicePath, OBJ_SEARCH_TYPE, PROFILE_QUERY_CONDITION) : 
                 queryFieldPermissionsApex(OBJ_SEARCH_TYPE, PROFILE_QUERY_CONDITION);
         } catch (Exception ex) {
@@ -97,7 +95,7 @@ public with sharing class rflib_PermissionsExplorerController {
     public static QueryResult getObjectLevelSecurityForAllPermissionSets(String servicePath){
         try {
             LOGGER.info('getObjectLevelSecurityForAllPermissionSets: servicePath=' + servicePath);
-            return useRestQueryModel() ? 
+            return shouldUseRestQueryModel() ? 
                 queryFieldPermissionsRest(servicePath, OBJ_SEARCH_TYPE, PERMISSION_SET_QUERY_CONDITION) : 
                 queryFieldPermissionsApex(OBJ_SEARCH_TYPE, PERMISSION_SET_QUERY_CONDITION);
         } catch (Exception ex) {
@@ -112,7 +110,7 @@ public with sharing class rflib_PermissionsExplorerController {
             LOGGER.info('getObjectLevelSecurityForUser: servicePath={0}, userId={1}', new Object[] { servicePath, userId});
             UserPermissionsDetails userPermissionDetails = getUserPermissionsDetails(userId);
 
-            return useRestQueryModel() ? 
+            return shouldUseRestQueryModel() ? 
                 queryFieldPermissionsRest(servicePath, OBJ_SEARCH_TYPE, getCompleteUserQueryCondition(userPermissionDetails)) : 
                 queryFieldPermissionsApex(OBJ_SEARCH_TYPE, getCompleteUserQueryCondition(userPermissionDetails));
         } catch (Exception ex) {
@@ -127,7 +125,7 @@ public with sharing class rflib_PermissionsExplorerController {
             LOGGER.info('getFieldLevelSecurityForUser: servicePath={0}, userId={1}', new Object[] { servicePath, userId});
             UserPermissionsDetails userPermissionDetails = getUserPermissionsDetails(userId);
 
-            return useRestQueryModel() ? 
+            return shouldUseRestQueryModel() ? 
                 queryFieldPermissionsRest(servicePath, FLS_SEARCH_TYPE, getCompleteUserQueryCondition(userPermissionDetails)) : 
                 queryFieldPermissionsApex(FLS_SEARCH_TYPE, getCompleteUserQueryCondition(userPermissionDetails));
         } catch (Exception ex) {
@@ -173,9 +171,10 @@ public with sharing class rflib_PermissionsExplorerController {
         return details;
     }
         
-    private static Boolean useRestQueryModel() {
-        LOGGER.info('REST API Enabled: {0}', new Object[] { queryMode } );
-        return String.isNotBlank(queryMode.Value__c) && Boolean.valueOf(queryMode.Value__c);
+    private static Boolean shouldUseRestQueryModel() {
+        Boolean result = rflib_GlobalSettings.useRestQueryModeForPermissionRetrievalOrDefault;
+        LOGGER.info('REST API Enabled: {0}', new Object[] { result } );
+        return result;
     }
 
     @SuppressWarnings('PMD.ApexSOQLInjection')

--- a/rflib/main/default/classes/rflib_SendLogEventEmailAction.cls
+++ b/rflib/main/default/classes/rflib_SendLogEventEmailAction.cls
@@ -42,7 +42,7 @@ public with sharing class rflib_SendLogEventEmailAction {
     private static final String HTML_MESSAGE = '<h2>A Log Event was created by {0}.</h2><h3>Request ID: {1}</h3><h3>Context: {2}</h3><p><b>Log Messages:</b> {3}</p></h3><p><b>Platform Info:</b> {4}</p>';
 
     @TestVisible
-    private static Boolean USE_ORG_WIDE_EMAIL_ADDRESS = rflib_GlobalSettings.useOrgWideEmailAddress;
+    private static Boolean USE_ORG_WIDE_EMAIL_ADDRESS = ! rflib_GlobalSettings.useDefaultWorkflowUserForLogEventsOrDefault;
 
     @TestVisible
     private static List<ApexEmailNotification> APEX_EMAIL_NOTIFICATION = [SELECT Email, UserId FROM ApexEmailNotification];

--- a/rflib/main/default/classes/rflib_SendLogEventEmailAction.cls
+++ b/rflib/main/default/classes/rflib_SendLogEventEmailAction.cls
@@ -42,7 +42,7 @@ public with sharing class rflib_SendLogEventEmailAction {
     private static final String HTML_MESSAGE = '<h2>A Log Event was created by {0}.</h2><h3>Request ID: {1}</h3><h3>Context: {2}</h3><p><b>Log Messages:</b> {3}</p></h3><p><b>Platform Info:</b> {4}</p>';
 
     @TestVisible
-    private static Boolean USE_ORG_WIDE_EMAIL_ADDRESS = true;
+    private static Boolean USE_ORG_WIDE_EMAIL_ADDRESS = rflib_GlobalSettings.useOrgWideEmailAddress;
 
     @TestVisible
     private static List<ApexEmailNotification> APEX_EMAIL_NOTIFICATION = [SELECT Email, UserId FROM ApexEmailNotification];

--- a/rflib/main/default/customMetadata/rflib_Global_Setting.Use_Default_Workflow_User_for_Log_Events.md-meta.xml
+++ b/rflib/main/default/customMetadata/rflib_Global_Setting.Use_Default_Workflow_User_for_Log_Events.md-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Use Org Wide Email Address</label>
+    <label>Use Default Workflow User for Log Events</label>
     <protected>false</protected>
     <values>
         <field>Value__c</field>
-        <value xsi:type="xsd:string">TRUE</value>
+        <value xsi:type="xsd:string">FALSE</value>
     </values>
 </CustomMetadata>

--- a/rflib/main/default/customMetadata/rflib_Global_Setting.Use_Org_Wide_Email_Address.md-meta.xml
+++ b/rflib/main/default/customMetadata/rflib_Global_Setting.Use_Org_Wide_Email_Address.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Use Org Wide Email Address</label>
+    <protected>false</protected>
+    <values>
+        <field>Value__c</field>
+        <value xsi:type="xsd:string">TRUE</value>
+    </values>
+</CustomMetadata>

--- a/rflib/test/default/classes/rflib_ApplicationEventArchiverTest.cls
+++ b/rflib/test/default/classes/rflib_ApplicationEventArchiverTest.cls
@@ -38,10 +38,8 @@ private class rflib_ApplicationEventArchiverTest {
 
         rflib_ApplicationEventArchiver.APPLICATION_EVENT_SERVICE = mockApplicationEventService;
         rflib_ApplicationEventArchiver.TODAY = TODAY;
-        rflib_ApplicationEventArchiver.APPLICATION_EVENT_RETAIN_X_DAYS = new rflib_Global_Setting__mdt(
-            DeveloperName = 'Application_Event_Retain_X_Days',
-            Value__c = '30'
-        );
+        
+        rflib_GlobalSettings.SETTINGS.put('Application_Event_Retain_X_Days', '30');
 
         List<rflib_Application_Event__c> events = new List<rflib_Application_Event__c>{
             new rflib_Application_Event__c(

--- a/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
+++ b/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
@@ -241,7 +241,7 @@ public class rflib_DefaultLoggerTest {
   }
 
   @IsTest
-  private static void testSyncLogEventPublisher_publishingLimits() {
+  private static void testSyncLogEventPublisher_publishingLimitOrDefaults() {
     rflib_Logger logger = new rflib_DefaultLogger(
       new rflib_DefaultLogger.LogEventPublisher(), 
       new rflib_DefaultLogger.SystemDebugLogger(), 
@@ -255,7 +255,7 @@ public class rflib_DefaultLoggerTest {
     logger.reportLogs();
     System.assertEquals(1, Limits.getPublishImmediateDML());
     
-    rflib_GlobalSettings.overridePublishingLimit(1);
+    rflib_GlobalSettings.overridePublishingLimitOrDefault(1);
 
     logger.reportLogs();
     System.assertEquals(1, Limits.getPublishImmediateDML());
@@ -272,7 +272,7 @@ public class rflib_DefaultLoggerTest {
 
     logger.info('This is a test message');
 
-    rflib_GlobalSettings.overridePublishingLimit(null);
+    rflib_GlobalSettings.overridePublishingLimitOrDefault(null);
 
     Test.startTest();
     System.assertEquals(0, Limits.getPublishImmediateDML());

--- a/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
+++ b/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
@@ -114,4 +114,13 @@ private class rflib_GlobalSettingsTest {
         System.assertEquals(expectedValue, rflib_GlobalSettings.useRestQueryModeForPermissionRetrievalOrDefault);
         Test.stopTest();
     }
+
+    @IsTest
+    static void testUseDefaultWorkflowUserForLogEvents() {
+        Boolean expectedValue = Boolean.valueOf(rflib_Global_Setting__mdt.getInstance('Use_Default_Workflow_User_for_Log_Events').Value__c);
+
+        Test.startTest();
+        System.assertEquals(expectedValue, rflib_GlobalSettings.useDefaultWorkflowUserForLogEventsOrDefault);
+        Test.stopTest();
+    }
 }

--- a/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
+++ b/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
@@ -87,4 +87,31 @@ private class rflib_GlobalSettingsTest {
         }
         Test.stopTest();
     }
+
+    @IsTest
+    static void testDaysToRetainApplicationEvents() {
+        Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Application_Event_Retain_X_Days').Value__c);
+
+        Test.startTest();
+        System.assertEquals(expectedValue, rflib_GlobalSettings.daysToRetainApplicationEvents);
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testArchiveLogQueryLimit() {
+        Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Archive_Log_Query_Limit').Value__c);
+
+        Test.startTest();
+        System.assertEquals(expectedValue, rflib_GlobalSettings.archiveLogQueryLimit);
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testUseRestQueryModeForPermissionRetrieval() {
+        Boolean expectedValue = Boolean.valueOf(rflib_Global_Setting__mdt.getInstance('Permissions_Explorer_REST_API_Enabled').Value__c);
+
+        Test.startTest();
+        System.assertEquals(expectedValue, rflib_GlobalSettings.useRestQueryModeForPermissionRetrieval);
+        Test.stopTest();
+    }
 }

--- a/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
+++ b/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
@@ -31,56 +31,56 @@
 private class rflib_GlobalSettingsTest {
 
     @IsTest
-    static void testTraceIdHeaderName() {
+    static void testTraceIdHeaderNameOrDefault() {
         String expectedValue = rflib_Global_Setting__mdt.getInstance('Trace_ID_Header_Name').Value__c;
 
         Test.startTest();
-        System.assertEquals(expectedValue, rflib_GlobalSettings.traceIdHeaderName);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.traceIdHeaderNameOrDefault);
         Test.stopTest();
     }
 
     @IsTest
-    static void testPublishingLimit() {
+    static void testPublishingLimitOrDefault() {
         Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
 
         Test.startTest();
-        System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimit);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimitOrDefault);
         Test.stopTest();
     }
 
     @IsTest
-    static void testOverridePublishingLimit_Success() {
+    static void testOverridePublishingLimitOrDefault_Success() {
         Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
 
         Test.startTest();
-        rflib_GlobalSettings.overridePublishingLimit(5);
-        System.assertEquals(5, rflib_GlobalSettings.publishingLimit);
+        rflib_GlobalSettings.overridePublishingLimitOrDefault(5);
+        System.assertEquals(5, rflib_GlobalSettings.publishingLimitOrDefault);
         Test.stopTest();
     }
 
 
     @IsTest
-    static void testOverridePublishingLimit_NullValue() {
+    static void testOverridePublishingLimitOrDefault_NullValue() {
         Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
 
         Test.startTest();
-        rflib_GlobalSettings.overridePublishingLimit(0);
-        System.assertEquals(0, rflib_GlobalSettings.publishingLimit);
+        rflib_GlobalSettings.overridePublishingLimitOrDefault(0);
+        System.assertEquals(0, rflib_GlobalSettings.publishingLimitOrDefault);
         
-        rflib_GlobalSettings.overridePublishingLimit(null);
-        System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimit);
+        rflib_GlobalSettings.overridePublishingLimitOrDefault(null);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimitOrDefault);
         Test.stopTest();
     }
 
     @IsTest
-    static void testOverridePublishingLimit_ValueExceedsLimit() {
+    static void testOverridePublishingLimitOrDefault_ValueExceedsLimit() {
         Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit').Value__c);
 
         Test.startTest();
-        System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimit);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.publishingLimitOrDefault);
         
         try {
-            rflib_GlobalSettings.overridePublishingLimit(Limits.getLimitPublishImmediateDML() + 1);
+            rflib_GlobalSettings.overridePublishingLimitOrDefault(Limits.getLimitPublishImmediateDML() + 1);
             System.assert(false, 'Expected rflib_InvalidArgumentException has not been thrown');
         } catch (rflib_InvalidArgumentException ex) {
             System.assert(ex.getMessage().contains('is less than 0 or higher than allowed limit'));
@@ -93,7 +93,7 @@ private class rflib_GlobalSettingsTest {
         Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Application_Event_Retain_X_Days').Value__c);
 
         Test.startTest();
-        System.assertEquals(expectedValue, rflib_GlobalSettings.daysToRetainApplicationEvents);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.daysToRetainApplicationEventsOrDefault);
         Test.stopTest();
     }
 
@@ -102,7 +102,7 @@ private class rflib_GlobalSettingsTest {
         Integer expectedValue = Integer.valueOf(rflib_Global_Setting__mdt.getInstance('Archive_Log_Query_Limit').Value__c);
 
         Test.startTest();
-        System.assertEquals(expectedValue, rflib_GlobalSettings.archiveLogQueryLimit);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.archiveLogQueryLimitOrDefault);
         Test.stopTest();
     }
 
@@ -111,7 +111,7 @@ private class rflib_GlobalSettingsTest {
         Boolean expectedValue = Boolean.valueOf(rflib_Global_Setting__mdt.getInstance('Permissions_Explorer_REST_API_Enabled').Value__c);
 
         Test.startTest();
-        System.assertEquals(expectedValue, rflib_GlobalSettings.useRestQueryModeForPermissionRetrieval);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.useRestQueryModeForPermissionRetrievalOrDefault);
         Test.stopTest();
     }
 }

--- a/rflib/test/default/classes/rflib_HttpRequestTest.cls
+++ b/rflib/test/default/classes/rflib_HttpRequestTest.cls
@@ -55,13 +55,13 @@ private class rflib_HttpRequestTest {
         rflib_HttpRequest req = createRequest();
         HttpResponse resp = createResponse('testCommonRequestProperties');
 
-        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req.getPlatformRequest(), resp, new String[] { rflib_GlobalSettings.traceIdHeaderName }));
+        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req.getPlatformRequest(), resp, new String[] { rflib_GlobalSettings.traceIdHeaderNameOrDefault }));
 
         HttpResponse actualResponse = req.send();
         Test.stopTest();
 
         System.assertNotEquals(null, actualResponse);
-        System.assertEquals(UserInfo.getUserId() + '|' + Request.getCurrent().getRequestId(), req.getPlatformRequest().getHeader(rflib_GlobalSettings.traceIdHeaderName));
+        System.assertEquals(UserInfo.getUserId() + '|' + Request.getCurrent().getRequestId(), req.getPlatformRequest().getHeader(rflib_GlobalSettings.traceIdHeaderNameOrDefault));
         
         assertResponse(resp, actualResponse);
     }
@@ -75,7 +75,7 @@ private class rflib_HttpRequestTest {
         rflib_HttpRequest req = createRequest();
         HttpResponse resp = createResponse('testSend_withLogTimer');
 
-        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req.getPlatformRequest(), resp, new String[] { rflib_GlobalSettings.traceIdHeaderName }));
+        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req.getPlatformRequest(), resp, new String[] { rflib_GlobalSettings.traceIdHeaderNameOrDefault }));
 
         logTimer.start(logger, rflib_LogLevel.WARN, -1, 'HttpRequest timer');
         HttpResponse actualResponse = req.send(logTimer);

--- a/rflib/test/default/classes/rflib_PermissionsExplorerControllerTest.cls
+++ b/rflib/test/default/classes/rflib_PermissionsExplorerControllerTest.cls
@@ -69,9 +69,7 @@ private class rflib_PermissionsExplorerControllerTest {
     private static final String METHOD = 'GET';
 
     private static void setup(Boolean isRestApiEnabled) {
-        rflib_PermissionsExplorerController.queryMode = new rflib_Global_Setting__mdt(
-            Value__c = String.valueOf(isRestApiEnabled)
-        );
+        rflib_GlobalSettings.SETTINGS.put('Permissions_Explorer_REST_API_Enabled', String.valueOf(isRestApiEnabled));
     }
 
     @IsTest
@@ -249,9 +247,6 @@ private class rflib_PermissionsExplorerControllerTest {
             String.format(FLS_USER_QUERY, new String[] { '\'' + UserInfo.getProfileId() + '\'', getPermissionSetsAsQueryString()}), 
             'UTF-8'
         ));
-        HttpResponse resp = createResponse(OBJ_RESPONSE);
-
-        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req.getPlatformRequest(), resp));
 
         CalloutException expectedEx = new CalloutException('something went wrong');
 
@@ -332,10 +327,6 @@ private class rflib_PermissionsExplorerControllerTest {
         );
 
         rflib_HttpRequest req = createRequest(ENDPOINT_PATH + EncodingUtil.urlEncode(OBJ_PROFILE_QUERY, 'UTF-8'));
-        HttpResponse resp = createResponse(OBJ_RESPONSE);
-
-        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req.getPlatformRequest(), resp));
-
         CalloutException expectedEx = new CalloutException('something went wrong');
 
         Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req.getPlatformRequest(), expectedEx));
@@ -374,10 +365,6 @@ private class rflib_PermissionsExplorerControllerTest {
         );
 
         rflib_HttpRequest req = createRequest(ENDPOINT_PATH + EncodingUtil.urlEncode(OBJ_PERMISSION_SET_QUERY, 'UTF-8'));
-        HttpResponse resp = createResponse(OBJ_RESPONSE);
-
-        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req.getPlatformRequest(), resp));
-
         CalloutException expectedEx = new CalloutException('something went wrong');
 
         Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req.getPlatformRequest(), expectedEx));
@@ -419,9 +406,6 @@ private class rflib_PermissionsExplorerControllerTest {
             String.format(OBJ_USER_QUERY, new String[] { '\'' + UserInfo.getProfileId() + '\'', getPermissionSetsAsQueryString()}), 
             'UTF-8'
         ));
-        HttpResponse resp = createResponse(OBJ_RESPONSE);
-
-        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req.getPlatformRequest(), resp));
 
         CalloutException expectedEx = new CalloutException('something went wrong');
 


### PR DESCRIPTION
Added new Global Setting config value to choose whether to use the Org Wide Email Address for sending out notifications or not.
This allows orgs to take advantage of the new configuration setting to select the workflow user for record triggered flows. See https://help.salesforce.com/s/articleView?id=release-notes.rn_automate_flow_builder_run_event_triggered_flows_as_workflow_user.htm&release=248&type=5