### PR TITLE
Trigger Framework: Refactored handling of Feature Switches to invert …

### DIFF
--- a/rflib-tf/main/default/classes/rflib_RetryableActionManager.cls
+++ b/rflib-tf/main/default/classes/rflib_RetryableActionManager.cls
@@ -47,7 +47,7 @@ public inherited sharing class rflib_RetryableActionManager {
     public static void dispatch(List<rflib_Retryable_Action__e> events) {
         LOGGER.info('Dispatching actions: ' + events);
 
-        if (rflib_FeatureSwitch.isTurnedOff('All_Retryable_Actions')) {
+        if (rflib_FeatureSwitch.isTurnedOn('rflib_Disable_All_Retryable_Actions')) {
             LOGGER.warn('The All Retryable Actions Feature switch is turned off, exiting execution.');
             return;
         }

--- a/rflib-tf/main/default/classes/rflib_TriggerManager.cls
+++ b/rflib-tf/main/default/classes/rflib_TriggerManager.cls
@@ -64,7 +64,7 @@ public inherited sharing class rflib_TriggerManager {
     private static void dispatch(rflib_TriggerManager.Args args) {
         List<TriggerHandlerInfo> handlers = getHandlers(args);
 
-        if (rflib_FeatureSwitch.isTurnedOff('All_Triggers')) {
+        if (rflib_FeatureSwitch.isTurnedOn('rflib_Disable_All_Triggers')) {
             LOGGER.warn('The All Trigger Feature switch is turned off, exiting trigger execution.');
             return;
         }

--- a/rflib-tf/test/default/classes/rflib_RetryableActionManagerTest.cls
+++ b/rflib-tf/test/default/classes/rflib_RetryableActionManagerTest.cls
@@ -38,15 +38,17 @@ private class rflib_RetryableActionManagerTest {
         rflib_RetryableActionManager.ALL_CONFIG_VALUES = new List<rflib_Retryable_Action_Config__mdt> {
             createConfiguration('Action_One', 1)
         };
+
+        rflib_FeatureSwitch.DEFAULT_VALUE = false; // Needs to be set for backwards version compatibility
     }
 
     @IsTest
-    public static void testRun_AllRetryableActionsFeatureSwitchOff() {
+    public static void testRun_DisableAllRetryableActionsFeatureSwitchOn() {
         setup();
 
         rflib_FeatureSwitch.featureSwitches = new Map<String,Map<String,Boolean>> {
-            'All_Retryable_Actions' => new Map<String,Boolean> {
-                rflib_FeatureSwitch.GLOBAL_SCOPE => false   
+            'rflib_Disable_All_Retryable_Actions' => new Map<String,Boolean> {
+                rflib_FeatureSwitch.GLOBAL_SCOPE => true   
             }
         };
 

--- a/rflib-tf/test/default/classes/rflib_TriggerManagerTest.cls
+++ b/rflib-tf/test/default/classes/rflib_TriggerManagerTest.cls
@@ -51,15 +51,17 @@ private class rflib_TriggerManagerTest {
             OBJECT_TYPE_NAME, 
             AFTER_INSERT
         );
+
+        rflib_FeatureSwitch.DEFAULT_VALUE = false; // Needs to be set for backwards version compatibility
     }
 
     @IsTest
-    public static void testRun_AllTriggersFeatureSwitchOff() {
+    public static void testRun_DisableAllTriggersFeatureSwitchOn() {
         setup(ABORT_TRANSACTION);
 
         rflib_FeatureSwitch.featureSwitches = new Map<String,Map<String,Boolean>> {
-            'All_Triggers' => new Map<String,Boolean> {
-                rflib_FeatureSwitch.GLOBAL_SCOPE => false   
+            'rflib_Disable_All_Triggers' => new Map<String,Boolean> {
+                rflib_FeatureSwitch.GLOBAL_SCOPE => true   
             }
         };
 


### PR DESCRIPTION
Trigger Framework: Refactored handling of Feature Switches to invert behaviour so that they don't need to be configured. CHANGED NAME OF FEATURE SWITCHES FOR TRIGGERS AND RETRYABLE ACTION. |
Renamed the Feature Switches used from `All_Triggers` to `rflib_Disable_All_Triggers` and from `All_Retryable_Actions` to `rflib_Disable_All_Retryable_Actions`. The old values will not be considered anymore.
**IMPORTANT: THIS CHANGE BREAKS BACKWARDS COMPATIBILITY IF THOSE TRIGGER SWITCHES ARE USED.**