### PR TITLE
Feature/trace id modes

### DIFF
--- a/rflib/main/default/classes/rflib_GlobalSettings.cls
+++ b/rflib/main/default/classes/rflib_GlobalSettings.cls
@@ -50,6 +50,9 @@ public class rflib_GlobalSettings {
     private static final String TRACE_ID_HEADER_NAME_DEFAULT_VALUE = 'X-Trace-ID';
     
     @TestVisible
+    private static final String TRACE_ID_VALUE_FORMAT = 'USER18_REQUEST_ID'; 
+    
+    @TestVisible
     private static final Boolean USE_DEFAULT_WORKFLOW_USER_FOR_LOG_EVENTS_DEFAULT_VALUE = false;    
     
     @TestVisible
@@ -95,6 +98,13 @@ public class rflib_GlobalSettings {
             return String.isBlank(val) ? TRACE_ID_HEADER_NAME_DEFAULT_VALUE : val;
         }
     }
+
+    public static String traceIdValueFormatOrDefault {
+        get {
+            String val = getSetting('Trace_ID_Value_Format');
+            return String.isBlank(val) ? TRACE_ID_VALUE_FORMAT : val;
+        }
+    }
     
     public static Boolean useDefaultWorkflowUserForLogEventsOrDefault {
         get {
@@ -103,21 +113,21 @@ public class rflib_GlobalSettings {
         }
     }
     
-    public static Boolean httpRequestMockingEnabled {
+    public static Boolean httpRequestMockingEnabledOrDefault {
         get {
             String val = getSetting('Http_Mocking_Enabled');
             return String.isBlank(val) ? HTTP_REQUEST_MOCKING_ENABLED : Boolean.valueOf(val);
         }
     }
     
-    public static Boolean httpRequestMockingAllowInProduction {
+    public static Boolean httpRequestMockingAllowInProductionOrDefault {
         get {
             String val = getSetting('Http_Mocking_Allow_In_Production');
             return String.isBlank(val) ? HTTP_REQUEST_MOCKING_ALLOW_IN_PRODUCTION : Boolean.valueOf(val);
         }
     }
     
-    public static Boolean httpRequestMockingThrowErrorIfNotMockNotFound {
+    public static Boolean httpRequestMockingThrowErrorIfNotMockNotFoundOrDefault {
         get {
             String val = getSetting('Http_Mocking_Throw_Error_If_Not_Found');
             return String.isBlank(val) ? HTTP_REQUEST_MOCKING_THROW_ERROR_IF_MOCK_NOT_FOUND : Boolean.valueOf(val);

--- a/rflib/main/default/classes/rflib_GlobalSettings.cls
+++ b/rflib/main/default/classes/rflib_GlobalSettings.cls
@@ -155,7 +155,8 @@ public class rflib_GlobalSettings {
             throw new rflib_InvalidArgumentException('newLimit', 'value provided (' + newLimit + ') is less than 0 or higher than allowed limit: ' + Limits.getPublishImmediateDML());
         }
 
-        String newLimitStr = newLimit != null ? String.valueOf(newLimit) : rflib_Global_Setting__mdt.getInstance('Publish_Platform_Event_Transaction_Limit')?.Value__c;
-        SETTINGS.put('Publish_Platform_Event_Transaction_Limit', newLimitStr);
+        String keyName = 'Publish_Platform_Event_Transaction_Limit';
+        String newLimitStr = newLimit != null ? String.valueOf(newLimit) : rflib_Global_Setting__mdt.getInstance(keyName)?.Value__c;
+        SETTINGS.put(keyName, newLimitStr);
     }
 }

--- a/rflib/main/default/classes/rflib_HttpRequest.cls
+++ b/rflib/main/default/classes/rflib_HttpRequest.cls
@@ -64,9 +64,9 @@ public with sharing class rflib_HttpRequest {
             delegatee.setHeader(rflib_GlobalSettings.traceIdHeaderNameOrDefault, rflib_TraceId.value);
 
             if (!suppressMocking && 
-                rflib_GlobalSettings.httpRequestMockingEnabled && (
+                rflib_GlobalSettings.httpRequestMockingEnabledOrDefault && (
                     rflib_OrgUtil.isSandboxOrg() ||
-                    (rflib_OrgUtil.isProductionOrg() && rflib_GlobalSettings.httpRequestMockingAllowInProduction)
+                    (rflib_OrgUtil.isProductionOrg() && rflib_GlobalSettings.httpRequestMockingAllowInProductionOrDefault)
             )) {
                 HttpResponse mockResponse = rflib_HttpEndpointMocker.getMockResponse(delegatee);
 
@@ -74,7 +74,7 @@ public with sharing class rflib_HttpRequest {
                     return mockResponse;
                 }
 
-                if (rflib_GlobalSettings.httpRequestMockingThrowErrorIfNotMockNotFound) {
+                if (rflib_GlobalSettings.httpRequestMockingThrowErrorIfNotMockNotFoundOrDefault) {
                     throw new CalloutException('No matching RFLIB HTTP Mock Endpoint configuration found; please check the CMT object.');
                 }
             }

--- a/rflib/main/default/classes/rflib_TraceId.cls
+++ b/rflib/main/default/classes/rflib_TraceId.cls
@@ -35,7 +35,21 @@
 @SuppressWarnings('PMD.ClassNamingConventions')
 public with sharing class rflib_TraceId {
     
-    public static String value = UserInfo.getUserId() + '|' + Request.getCurrent().getRequestId();
+    public static String value {
+        get {
+            switch on rflib_GlobalSettings.traceIdValueFormatOrDefault.toUpperCase() {
+                when 'REQUEST_ID' {
+                    return Request.getCurrent().getRequestId();
+                }
+                when 'USER15_REQUEST_ID' {
+                    return Id.valueOf(UserInfo.getUserId()).to15() + '|' + Request.getCurrent().getRequestId();
+                }
+                when else {
+                    return UserInfo.getUserId() + '|' + Request.getCurrent().getRequestId();
+                }
+            }
+        }
+    }
     
     @TestVisible
     @SuppressWarnings('PMD.EmptyStatementBlock')

--- a/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
+++ b/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
@@ -125,29 +125,38 @@ private class rflib_GlobalSettingsTest {
     }
 
     @IsTest
-    static void testHttpRequestMockingEnabled() {
+    static void testHttpRequestMockingEnabledOrDefault() {
         Boolean expectedValue = getConfiguredBooleanValueOrDefault('Http_Mocking_Enabled', rflib_GlobalSettings.HTTP_REQUEST_MOCKING_ENABLED);
 
         Test.startTest();
-        System.assertEquals(expectedValue, rflib_GlobalSettings.httpRequestMockingEnabled);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.httpRequestMockingEnabledOrDefault);
         Test.stopTest();
     }
 
     @IsTest
-    static void testHttpRequestMockingAllowInProduction() {
+    static void testHttpRequestMockingAllowInProductionOrDefault() {
         Boolean expectedValue = getConfiguredBooleanValueOrDefault('Http_Mocking_Allow_In_Production', rflib_GlobalSettings.HTTP_REQUEST_MOCKING_ALLOW_IN_PRODUCTION);
 
         Test.startTest();
-        System.assertEquals(expectedValue, rflib_GlobalSettings.httpRequestMockingAllowInProduction);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.httpRequestMockingAllowInProductionOrDefault);
         Test.stopTest();
     }
 
     @IsTest
-    static void testHttpRequestMockingThrowErrorIfNotMockNotFound() {
+    static void testHttpRequestMockingThrowErrorIfNotMockNotFoundOrDefault() {
         Boolean expectedValue = getConfiguredBooleanValueOrDefault('Http_Mocking_Throw_Error_If_Not_Found', rflib_GlobalSettings.HTTP_REQUEST_MOCKING_THROW_ERROR_IF_MOCK_NOT_FOUND);
 
         Test.startTest();
-        System.assertEquals(expectedValue, rflib_GlobalSettings.httpRequestMockingThrowErrorIfNotMockNotFound);
+        System.assertEquals(expectedValue, rflib_GlobalSettings.httpRequestMockingThrowErrorIfNotMockNotFoundOrDefault);
+        Test.stopTest();
+    }
+
+    @IsTest
+    static void testTraceIdModeOrDefault() {
+        String expectedValue = getConfiguredStringValueOrDefault('Trace_ID_Value_Format', rflib_GlobalSettings.TRACE_ID_VALUE_FORMAT);
+
+        Test.startTest();
+        System.assertEquals(expectedValue, rflib_GlobalSettings.traceIdValueFormatOrDefault);
         Test.stopTest();
     }
 

--- a/rflib/test/default/classes/rflib_TraceIdTest.cls
+++ b/rflib/test/default/classes/rflib_TraceIdTest.cls
@@ -31,8 +31,43 @@
 private class rflib_TraceIdTest {
 
     @IsTest
-    private static void testValue(){
+    private static void testDefaultMode(){
         System.assertEquals(UserInfo.getUserId() + '|' + Request.getCurrent().getRequestId(), rflib_TraceId.value);        
+    }
+
+    @IsTest
+    private static void testUser18Mode(){
+        rflib_GlobalSettings.SETTINGS.put('Trace_ID_Value_Format', 'USER18_REQUEST_ID');
+
+        System.assertEquals(UserInfo.getUserId() + '|' + Request.getCurrent().getRequestId(), rflib_TraceId.value);        
+    }
+    
+    @IsTest
+    private static void testTraceIdModeUnsupported(){
+        rflib_GlobalSettings.SETTINGS.put('Trace_ID_Value_Format', 'UNSUPPORTED');
+
+        System.assertEquals(UserInfo.getUserId() + '|' + Request.getCurrent().getRequestId(), rflib_TraceId.value);        
+    }
+    
+    @IsTest
+    private static void testUser15Mode(){
+        rflib_GlobalSettings.SETTINGS.put('Trace_ID_Value_Format', 'USER15_REQUEST_ID');
+
+        System.assertEquals(Id.valueOf(UserInfo.getUserId()).to15() + '|' + Request.getCurrent().getRequestId(), rflib_TraceId.value);        
+    }
+    
+    @IsTest
+    private static void testRequestIdMode(){
+        rflib_GlobalSettings.SETTINGS.put('Trace_ID_Value_Format', 'REQUEST_ID');
+
+        System.assertEquals(Request.getCurrent().getRequestId(), rflib_TraceId.value);        
+    }
+
+    @IsTest
+    private static void testRequestIdMode_Lowercase(){
+        rflib_GlobalSettings.SETTINGS.put('Trace_ID_Value_Format', 'request_id');
+
+        System.assertEquals(Request.getCurrent().getRequestId(), rflib_TraceId.value);        
     }
 
     @IsTest


### PR DESCRIPTION
Added new Global Setting called Trace_ID_Value_Format which allows for the setting of two new Trace ID value formats: SF Request ID only or current user's record ID (either 15 or 18 char) + SF Request ID.
