### PR TITLE
Bundle OmniStudio support in the logging framework

### DIFF
--- a/rflib/main/default/classes/rflib_OmniStudioRemoteActions.cls
+++ b/rflib/main/default/classes/rflib_OmniStudioRemoteActions.cls
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 Johannes Fischer <fischer.jh@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name "RFLIB", the name of the copyright holder, nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+@SuppressWarnings('PMD.ClassNamingConventions')
+global class rflib_OmniStudioRemoteActions implements System.Callable {
+    @TestVisible
+    private static rflib_LoggerFactory loggerFactory = rflib_LoggerUtil.getFactory();
+    @TestVisible
+    private static rflib_ApplicationEventLogger applicationEventLogger = rflib_LoggerUtil.getApplicationEventLogger();
+
+    global Object call(String action, Map<String, Object> args) {
+        Map<String, Object> input = (Map<String, Object>)args.get('input');
+        Map<String, Object> output = (Map<String, Object>)args.get('output');
+        Map<String, Object> options = (Map<String, Object>)args.get('options');
+
+        return this.invokeMethod(action, input, output, options);
+    }
+
+    private Boolean invokeMethod(String methodName, Map<String,Object> input, Map<String,Object> output, Map<String,Object> option) {
+        System.debug('*** Input Parameters *** ' + input);
+
+        if (methodName == 'LogMessage') {
+            logMessage(input);
+        } else if (methodName == 'LogApplicationEvent') {
+            logApplicationEvent(input);
+        } else {
+            output.put('errorMessage', 'Invalid method name: ' + methodName);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void logMessage(Map<String,Object> input) {
+        String context = (String)input.get('context');
+        String logLevel = (String)input.get('level');
+        String message = (String)input.get('message');
+        List<String> args = parseArgs((String)input.get('args'));
+
+        rflib_Logger logger = loggerFactory.createLogger(context);
+
+        switch on logLevel.toUpperCase() {
+            when 'FATAL' {
+                logger.fatal(message, args);
+            }
+            when 'ERROR' {
+                logger.error(message, args);
+            }
+            when 'WARN' {
+                logger.warn(message, args);
+            }
+            when 'INFO' {
+                logger.info(message, args);
+            }
+            when 'DEBUG' {
+                logger.debug(message, args);
+            }
+            when else {
+                logger.debug(message, args);
+            }
+        }
+    }
+
+    private static void logApplicationEvent(Map<String,Object> input) {
+        String eventName = (String)input.get('eventName');
+        String relatedRecordId = (String)input.get('relatedRecordId');
+        String additionalDetails = (String)input.get('additionalDetails');
+
+        applicationEventLogger.logApplicationEvent(eventName, relatedRecordId, additionalDetails);
+    }
+
+    private static List<String> parseArgs(String argsJson) {
+        if (String.isNotBlank(argsJson)) {
+            try {
+                return (List<String>) JSON.deserialize(argsJson, List<String>.class);
+            } catch (JSONException e) {
+                System.debug('Failed to parse args JSON: ' + e.getMessage());
+                return new List<String>();
+            }
+        }
+        return new List<String>();
+    }
+}

--- a/rflib/main/default/classes/rflib_OmniStudioRemoteActions.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_OmniStudioRemoteActions.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rflib/test/default/classes/rflib_OmniStudioRemoteActionsTest.cls
+++ b/rflib/test/default/classes/rflib_OmniStudioRemoteActionsTest.cls
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2024 Johannes Fischer <fischer.jh@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name "RFLIB", the name of the copyright holder, nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+@IsTest
+@SuppressWarnings('PMD.ClassNamingConventions')
+private class rflib_OmniStudioRemoteActionsTest {
+
+    private static final rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory(rflib_LogLevel.DEBUG);
+    private static final rflib_MockApplicationEventLogger applicationEventLogger = new rflib_MockApplicationEventLogger();
+
+    static void setup() {
+        rflib_OmniStudioRemoteActions.loggerFactory = loggerFactory;
+        rflib_OmniStudioRemoteActions.applicationEventLogger = applicationEventLogger;
+    }
+
+    @IsTest
+    private static void testLogMessage_Fatal() {
+        runLogMessageTest('FATAL', 'FATAL');
+    }
+
+    @IsTest
+    private static void testLogMessage_Error() {
+        runLogMessageTest('ERROR', 'ERROR');
+    }
+
+    @IsTest
+    private static void testLogMessage_Warn() {
+        runLogMessageTest('WARN', 'WARN');
+    }
+
+    @IsTest
+    private static void testLogMessage_Info() {
+        runLogMessageTest('INFO', 'INFO');
+    }
+
+    @IsTest
+    private static void testLogMessage_Debug() {
+        runLogMessageTest('DEBUG', 'DEBUG');
+    }
+
+    @IsTest
+    private static void testLogMessage_UnknownLogLevel() {
+        runLogMessageTest('FOOBAR', 'DEBUG');
+    }
+
+    @IsTest
+    private static void testLogApplicationEvent() {
+        setup();
+
+        rflib_MockApplicationEventLogger mockAppEventLogger = new rflib_MockApplicationEventLogger();
+        rflib_OmniStudioRemoteActions.applicationEventLogger = mockAppEventLogger;
+
+        String eventName = 'TestEvent';
+        String relatedRecordId = '001xx000003DHP0';
+        String additionalDetails = 'Additional details for the event';
+
+        Map<String, Object> input = new Map<String, Object>{
+            'eventName' => eventName,
+            'relatedRecordId' => relatedRecordId,
+            'additionalDetails' => additionalDetails
+        };
+        Map<String, Object> output = new Map<String, Object>();
+        Map<String, Object> options = new Map<String, Object>();
+
+        Map<String, Object> args = new Map<String, Object>{
+            'input' => input,
+            'output' => output,
+            'options' => options
+        };
+
+        Test.startTest();
+        rflib_OmniStudioRemoteActions controller = new rflib_OmniStudioRemoteActions();
+        Boolean result = (Boolean) controller.call('LogApplicationEvent', args);
+        Test.stopTest();
+
+        Assert.isTrue(result, 'Expected method to return true');
+        Assert.isNull(output.get('errorMessage'), 'Expected no error message');
+        Assert.areEqual(eventName, mockAppEventLogger.capturedEventName);
+        Assert.areEqual(relatedRecordId, mockAppEventLogger.capturedRelatedRecordId);
+        Assert.areEqual(additionalDetails, mockAppEventLogger.capturedAdditionalDetails);
+    }
+
+    @IsTest
+    private static void testInvalidMethodName() {
+        setup();
+
+        Map<String, Object> input = new Map<String, Object>();
+        Map<String, Object> output = new Map<String, Object>();
+        Map<String, Object> option = new Map<String, Object>();
+
+        Test.startTest();
+        rflib_OmniStudioRemoteActions controller = new rflib_OmniStudioRemoteActions();
+        Map<String, Object> callableInput = new Map<String, Object>{'input' => input, 'output' => output, 'option' => option};
+        Boolean result = (Boolean) controller.call('InvalidMethod', callableInput);
+        Test.stopTest();
+
+        Assert.isFalse(result, 'Expected method to return false');
+        Assert.areEqual('Invalid method name: InvalidMethod', output.get('errorMessage'));
+    }
+
+    @IsTest
+    private static void testCallMethod() {
+        setup();
+
+        String action = 'LogMessage';
+        String context = 'TestContext';
+        String logLevel = 'INFO';
+        String message = 'This is a test log message';
+        String argsJson = '["arg1", "arg2"]';
+
+        Map<String, Object> input = new Map<String, Object>{
+            'context' => context,
+            'level' => logLevel,
+            'message' => message,
+            'args' => argsJson
+        };
+        Map<String, Object> output = new Map<String, Object>();
+        Map<String, Object> options = new Map<String, Object>();
+
+        Map<String, Object> args = new Map<String, Object>{
+            'input' => input,
+            'output' => output,
+            'options' => options
+        };
+
+        Test.startTest();
+        rflib_OmniStudioRemoteActions controller = new rflib_OmniStudioRemoteActions();
+        Object result = controller.call(action, args);
+        Test.stopTest();
+
+        Assert.isTrue((Boolean)result, 'Expected method to return true');
+        Assert.isNull(output.get('errorMessage'), 'Expected no error message');
+        Assert.isTrue(loggerFactory.debugLogCapture.containsInAnyMessage(logLevel), 'debugLogger did not contain ' + logLevel + ' message');
+    }
+
+
+    private static void runLogMessageTest(String logLevel, String expectedLogLevel) {
+        setup();
+
+        String context = 'TestContext';
+        String message = 'This is a test log message';
+        String argsJson = '["arg1", "arg2"]';
+
+        Map<String, Object> input = new Map<String, Object>{
+            'context' => context,
+            'level' => logLevel,
+            'message' => message,
+            'args' => argsJson
+        };
+        Map<String, Object> output = new Map<String, Object>();
+        Map<String, Object> options = new Map<String, Object>();
+
+        Map<String, Object> args = new Map<String, Object>{
+            'input' => input,
+            'output' => output,
+            'options' => options
+        };
+
+        Test.startTest();
+        rflib_OmniStudioRemoteActions controller = new rflib_OmniStudioRemoteActions();
+        Boolean result = (Boolean) controller.call('LogMessage', args);
+        Test.stopTest();
+
+        Assert.isTrue(result, 'Expected method to return true');
+        Assert.isNull(output.get('errorMessage'), 'Expected no error message');
+        Assert.isTrue(loggerFactory.debugLogCapture.containsInAnyMessage(expectedLogLevel), 'debugLogger did not contain ' + expectedLogLevel + ' message');
+    }
+}

--- a/rflib/test/default/classes/rflib_OmniStudioRemoteActionsTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_OmniStudioRemoteActionsTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Hi @j-fischer - I don't think we've ever had the chance to meet/talk, but we're both logging nerds in the Salesforce ecosystem. I'm the creator of [Nebula Logger](https://github.com/jongpie/NebulaLogger), and I just added support for OmniStudio yesterday. I saw that you've provided OmniStudio support for a while, but it's not currently bundled into your package because you're using the Vlocity interfaces (in addition to `Callable`).

From what I've seen, the Vlocity interfaces aren't necessary, you can use just the `Callable` interface. In [Salesforce's docs](https://help.salesforce.com/s/articleView?id=ind.v_dev_t_callable_implementations_651821.htm&type=5), it says:

> Vlocity Apex classes and the Remote Actions of OmniScripts and Integration Procedures support the Callable interface beginning in the Summer '21 release.
>
> Although the VlocityOpenInterface and VlocityOpenInterface2 interfaces enable flexible implementations with a uniform signature, they reside in the Vlocity managed package and aren't truly Salesforce standards. However, classes that implement VlocityOpenInterface or VlocityOpenInterface2 also implement the Callable Interface, which is a Salesforce standard.
>
> In addition, Remote Actions of OmniScripts and Integration Procedures can invoke any class that implements Callable, regardless of whether it implements VlocityOpenInterface or VlocityOpenInterface2. You specify the Remote Class, Remote Method, and Additional Input properties in the same way for classes that implement any of these interfaces.

By using just the `Callable` interface, the code can be deployed to any Salesforce org, even if it doesn't have a version of OmniStudio. So, I thought I'd submit a PR with the changes to make your OmniStudio support available out of the box in rflib.

## Changes made:
- Copied your Apex class & test from [the wiki page](https://github.com/j-fischer/rflib/wiki/Getting-Started-with-Logging-in-OmniStudio)
- Removed references to the `VlocityOpenInterface` interface & switched to only use the `Callable` interface
  - I kept the `invokeMethod()`, but it's now `private` - only `call()` is exposed
- Updated your test methods to use the `call()` method (instead of `invokeMethod()`), and adjusted a few asserts as needed (due to the difference in return values for `call()` and `invokeMethod()`)
  - I also made a few very minor variable renames for consistency