### PR TITLE
Feature/log-aggregation

### DIFF
--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -30,525 +30,632 @@
 /**
  * @group Logger
  * @description Default rflib_Logger implementation, which is based on the configuration
- *              stored in the Logger Settings Custom Setting object. 
- */ 
+ *              stored in the Logger Settings Custom Setting object.
+ */
 @SuppressWarnings('PMD.ClassNamingConventions')
 public without sharing class rflib_DefaultLogger implements rflib_Logger {
+    @TestVisible
+    private static final Integer MAX_MESSAGE_SIZE = 131072;
+    @TestVisible
+    private static final List<String> LOG_STATEMENTS = new List<String>();
 
-  @TestVisible private static final Integer MAX_MESSAGE_SIZE = 131072;
-  @TestVisible private static final List<String> LOG_STATEMENTS = new List<String>(); 
+    @TestVisible
+    private static String PLATFORM_INFO = null;
 
-  @TestVisible private static String PLATFORM_INFO = null; 
+    private static final String APPLICATION_EVENT_NAME_PATTERN = 'rflib-{0}-{1}';
 
-  private static rflib_DefaultLogger.BatchLogEventExecutor BATCH_EXECUTOR = new rflib_DefaultLogger.BatchLogEventExecutor();
+    private static rflib_DefaultLogger.BatchLogEventExecutor BATCH_EXECUTOR = new rflib_DefaultLogger.BatchLogEventExecutor();
 
-  private final String context;
-  private final rflib_EventPublisher eventPublisher;
-  private final rflib_DefaultLogger.DebugLogger debugLogger;
-  private final List<String> logMessages;
+    private final String context;
+    private final rflib_EventPublisher eventPublisher;
+    private final rflib_DefaultLogger.DebugLogger debugLogger;
+    private final List<String> logMessages;
 
-  private Integer logCacheSize = 100;
-  private Boolean isLogMaskingEnabled = false;
+    private Integer logCacheSize = 100;
+    private Boolean isLogMaskingEnabled = false;
 
-  private rflib_LogLevel generalLogLevel = rflib_LogLevel.DEBUG;
-  private rflib_LogLevel systemDebugLevel = rflib_LogLevel.DEBUG;
-  private rflib_LogLevel reportingLogLevel = rflib_LogLevel.WARN;
-  private rflib_LogLevel flushLogStackLevel = rflib_LogLevel.NONE;
-  private rflib_LogLevel batchReportingLogLevel = rflib_LogLevel.NONE;
+    private rflib_LogLevel generalLogLevel = rflib_LogLevel.DEBUG;
+    private rflib_LogLevel systemDebugLevel = rflib_LogLevel.DEBUG;
+    private rflib_LogLevel reportingLogLevel = rflib_LogLevel.WARN;
+    private rflib_LogLevel flushLogStackLevel = rflib_LogLevel.NONE;
+    private rflib_LogLevel batchReportingLogLevel = rflib_LogLevel.NONE;
+    private rflib_LogLevel observabilityLogLevel = rflib_LogLevel.ERROR;
 
-  /**
-   * DEPRECATED - Use `new rflib_DefaultLoggerFactory.createLogger()` instead.
-   * 
-   * Create an rflib_Logger instance for the given context based on the configuration of the Logger Custom Settings
-   * associated with this user. Events are published immediately.
-   * 
-   * @param  context The context identifier for this logger instance.
-   * @return         A logger instance for the given context.
-   */
-  public static rflib_Logger createFromCustomSettings(String context) {
-    return createFromCustomSettings(context, false);
-  }
-
-  /**
-   * DEPRECATED - Use `new rflib_DefaultLoggerFactory.createLogger()` instead.
-   * 
-   * Create an rflib_Logger instance for the given context based on the configuration of the Logger Custom Settings
-   * associated with this user. Events are published in batches.
-   * 
-   * @param  context The context identifier for this logger instance.
-   * @return         A logger instance for the given context.
-   */
-  public static rflib_Logger createBatchedLoggerFromCustomSettings(String context) {
-    return createFromCustomSettings(context, true);
-  }
-
-  /**
-   * DEPRECATED - Use `new rflib_DefaultLoggerFactory.createLogger()` or `new rflib_DefaultLoggerFactory.createLogger()` 
-   *              depending on the value for `shouldPublishEventsInBatch` instead.
-   * 
-   * Create an rflib_Logger instance for the given context based on the configuration of the Logger Custom Settings
-   * associated with this user.
-   * 
-   * @param  context The context identifier for this logger instance.
-   * @param  shouldBatchEvents `Boolean` flag to indicate whether to publish events in batch or not. Batched events will require the invocation of `rflib_Logger.publishBatchedLogEvents()` to be dispatched.
-   * @return         A logger instance for the given context.
-   */
-  public static rflib_Logger createFromCustomSettings(String context, Boolean shouldPublishEventsInBatch) {
-    rflib_Logger logger = rflib_DefaultLogger.create(context, shouldPublishEventsInBatch);
-
-    rflib_Logger_Settings__c settings = rflib_Logger_Settings__c.getInstance();
-    if (settings.Log_Size__c != null) {
-      logger.setLogCacheSize(Integer.valueOf(settings.Log_Size__c));
+    /**
+     * DEPRECATED - Use `new rflib_DefaultLoggerFactory.createLogger()` instead.
+     *
+     * Create an rflib_Logger instance for the given context based on the configuration of the Logger Custom Settings
+     * associated with this user. Events are published immediately.
+     *
+     * @param  context The context identifier for this logger instance.
+     * @return         A logger instance for the given context.
+     */
+    public static rflib_Logger createFromCustomSettings(String context) {
+        return createFromCustomSettings(context, false);
     }
 
-    if (String.isNotBlank(settings.General_Log_Level__c)) {
-      logger.setGeneralLogLevel(rflib_LogLevel.fromString(settings.General_Log_Level__c));
+    /**
+     * DEPRECATED - Use `new rflib_DefaultLoggerFactory.createLogger()` instead.
+     *
+     * Create an rflib_Logger instance for the given context based on the configuration of the Logger Custom Settings
+     * associated with this user. Events are published in batches.
+     *
+     * @param  context The context identifier for this logger instance.
+     * @return         A logger instance for the given context.
+     */
+    public static rflib_Logger createBatchedLoggerFromCustomSettings(String context) {
+        return createFromCustomSettings(context, true);
     }
 
-    if (String.isNotBlank(settings.System_Debug_Log_Level__c)) {
-      logger.setSystemDebugLevel(rflib_LogLevel.fromString(settings.System_Debug_Log_Level__c));
-    }
+    /**
+     * DEPRECATED - Use `new rflib_DefaultLoggerFactory.createLogger()` or `new rflib_DefaultLoggerFactory.createLogger()`
+     *              depending on the value for `shouldPublishEventsInBatch` instead.
+     *
+     * Create an rflib_Logger instance for the given context based on the configuration of the Logger Custom Settings
+     * associated with this user.
+     *
+     * @param  context The context identifier for this logger instance.
+     * @param  shouldBatchEvents `Boolean` flag to indicate whether to publish events in batch or not. Batched events will require the invocation of `rflib_Logger.publishBatchedLogEvents()` to be dispatched.
+     * @return         A logger instance for the given context.
+     */
+    public static rflib_Logger createFromCustomSettings(String context, Boolean shouldPublishEventsInBatch) {
+        rflib_Logger logger = rflib_DefaultLogger.create(context, shouldPublishEventsInBatch);
 
-    if (String.isNotBlank(settings.Log_Event_Reporting_Level__c)) {
-      logger.setReportingLogLevel(rflib_LogLevel.fromString(settings.Log_Event_Reporting_Level__c));
-    }
-
-    if (String.isNotBlank(settings.Flush_Log_Cache_Level__c)) {
-      logger.setFlushLogCacheLevel(rflib_LogLevel.fromString(settings.Flush_Log_Cache_Level__c));
-    }
-
-    if (String.isNotBlank(settings.Batched_Log_Event_Reporting_Level__c)) {
-      logger.setBatchReportingLogLevel(rflib_LogLevel.fromString(settings.Batched_Log_Event_Reporting_Level__c));
-    }
-
-    logger.setLogMaskingState(settings.Enable_Log_Masking__c);
-
-    return logger;
-  }
-
-  /**
-   * Create a default logger instance for the given context. Default values for the logger are:
-   *    - cache size: 100
-   *    - general log level: DEBUG
-   *    - system debug level: DEBUG
-   *    - reporting log level: WARN
-   *    - event publishing: immediate
-   *
-   * @param  context The context for this logger.
-   * @return         The new logger instance for the given context.
-   */
-  public static rflib_Logger create(String context) {
-    return create(context, false);
-  }
-  
-  /**
-   * Create a default logger instance for the given context. Default values for the logger are:
-   *    - cache size: 100
-   *    - general log level: DEBUG
-   *    - system debug level: DEBUG
-   *    - reporting log level: WARN
-   *    - event publishing: immediate
-   *
-   * @param  context The context for this logger.
-   * @return         The new logger instance for the given context.
-   */
-  public static rflib_Logger createBatchedLogger(String context) {
-    return create(context, true);
-  }
-
-  /**
-   * Create a default logger instance for the given context. Default values for the logger are:
-   *    - cache size: 100
-   *    - general log level: DEBUG
-   *    - system debug level: DEBUG
-   *    - reporting log level: WARN
-   *    - event publishing: immediate
-   *
-   * @param  context The context for this logger.
-   * @param  shouldBatchEvents `Boolean` flag to indicate whether to publish events in batch or not. Batched events will require the invocation of `rflib_Logger.publishBatchedLogEvents()` to be dispatched.
-   * @return         The new logger instance for the given context.
-   */
-  public static rflib_Logger create(String context, Boolean shouldBatchEvents) {
-    return new rflib_DefaultLogger(context, shouldBatchEvents);
-  }
-  
-  private rflib_DefaultLogger(String context, Boolean shouldBatchEvents) {
-    this(
-      shouldBatchEvents ? 
-        (rflib_EventPublisher) new rflib_DefaultLogger.BatchLogEventPublisher() : 
-        (rflib_EventPublisher) new rflib_DefaultLogger.LogEventPublisher(), 
-      new rflib_DefaultLogger.SystemDebugLogger(), 
-      context
-    );
-  }
-
-  @TestVisible
-  private rflib_DefaultLogger(
-        rflib_EventPublisher eventPublisher, 
-        rflib_DefaultLogger.DebugLogger debugLogger, 
-        String context) {
-    this(eventPublisher, debugLogger, context, LOG_STATEMENTS);
-  }
-
-  private rflib_DefaultLogger(
-        rflib_EventPublisher eventPublisher, 
-        rflib_DefaultLogger.DebugLogger debugLogger, 
-        String context,
-        List<String> logMessages) {
-    this.eventPublisher = eventPublisher;
-    this.debugLogger = debugLogger;
-    this.context = context;
-    this.logMessages = logMessages;
-  }
-
-  public void setLogCacheSize(Integer newSize) {
-    logCacheSize = newSize;
-
-    Integer numberOfCollectedMessages = logMessages.size();
-    if (numberOfCollectedMessages > newSize) {
-      for (Integer i = 0; i < (numberOfCollectedMessages - newSize); i++) {
-        logMessages.remove(0);
-      }
-    }
-  } 
-
-  public void setReportingLogLevel(rflib_LogLevel newLevel) {
-    // NOTE: The reporting level can only be INFO or higher to prevent accidental
-    //       "floods" of Log Events being created. Following best practices, DEBUG and TRACE statements
-    //       should be used within loops and should ideally never cause a Log Event to be sent out.
-    //       It is recommended that most log statements should be INFO level to provide the most transparency
-    //       when reducing the reporting log level down to INFO. 
-    //       See https://github.com/j-fischer/rflib/issues/6 for more details.
-    reportingLogLevel = rflib_LogLevel.INFO.encompasses(newLevel) || rflib_LogLevel.NONE == newLevel ? 
-      newLevel : 
-      rflib_LogLevel.INFO;
-  }
-
-  public void setFlushLogCacheLevel(rflib_LogLevel newLevel) {
-    // NOTE: Because this log level is aligned with the reporting log level, the same restrictions 
-    //       apply with respect to the supported levels.
-    flushLogStackLevel = rflib_LogLevel.INFO.encompasses(newLevel) || rflib_LogLevel.NONE == newLevel ? 
-      newLevel : 
-      rflib_LogLevel.INFO;
-  }
-
-  public void setBatchReportingLogLevel(rflib_LogLevel newLevel) {
-    batchReportingLogLevel = newLevel;
-  }
-
-  public void setSystemDebugLevel(rflib_LogLevel newLevel) {
-    systemDebugLevel = newLevel;
-  }
-
-  public void setGeneralLogLevel(rflib_LogLevel newLevel) {
-    generalLogLevel = newLevel;
-  }
-
-  public void setLogMaskingState(Boolean isEnabled) {
-    isLogMaskingEnabled = isEnabled;
-  }
-
-  public void setPlatformInfo(String platformInfo) {
-    PLATFORM_INFO = platformInfo;
-  }
-
-  public void trace(String message) {
-    trace(message, null);
-  }
-
-  public void trace(String message, Object[] args) {
-    logMessage(rflib_LogLevel.TRACE, message, args, null);
-  }
-
-  public void debug(String message) {
-    debug(message, null);
-  }
-
-  public void debug(String message, Object[] args) {
-    logMessage(rflib_LogLevel.DEBUG, message, args, null);
-  }
-
-  public void info(String message){
-    info(message, null);
-  }
-
-  public void info(String message, Object[] args) {
-    logMessage(rflib_LogLevel.INFO, message, args, null);
-  }
-
-  public void warn(String message){
-    warn(message, null);
-  }
-
-  public void warn(String message, Object[] args) {
-    logMessage(rflib_LogLevel.WARN, message, args, null);
-  }
-
-  public void error(String message){
-    error(message, null, null);
-  }
-
-  public void error(String message, Exception ex){
-    error(message, null, ex);
-  }
-
-  public void error(String message, Object[] args) {
-    error(message, args, null);
-  }
-
-  public void error(String message, Object[] args, Exception ex) {
-    logMessage(rflib_LogLevel.ERROR, message, args, ex);
-  }
-
-  public void fatal(String message){
-    fatal(message, null, null);
-  }
-
-  public void fatal(String message, Exception ex){
-    fatal(message, null, ex);
-  }
-
-  public void fatal(String message, Object[] args) {
-    fatal(message, args, null);
-  }
-
-  public void fatal(String message, Object[] args, Exception ex) {
-    logMessage(rflib_LogLevel.FATAL, message, args, ex);
-  }
-
-  public String printLogs() {
-    String logMessages = 'Log statements reported by ' + context + ':\n' + String.join(logMessages, '\n');
-    debugLogger.debug(LoggingLevel.DEBUG, logMessages);
-    return logMessages;
-  }
-
-  public void reportLogs() {
-    reportLogs(rflib_LogLevel.DEBUG);
-  }
-
-  public void publishBatchedLogEvents() {
-    if (Limits.getDmlStatements() < Limits.getLimitDmlStatements()) {
-      BATCH_EXECUTOR.execute(null);
-    } else {
-      System.enqueueJob(BATCH_EXECUTOR);
-    }
-
-    BATCH_EXECUTOR = new rflib_DefaultLogger.BatchLogEventExecutor();
-  }
-
-  private void reportLogs(rflib_LogLevel logLevel) {
-    String messagesAsStr = String.join(logMessages, '\n');
-    
-    // It is important to run the masking rules first as those could change the size of the string, possibly making it larger.
-    String maskedLogMessagesIfApplicable = isLogMaskingEnabled ? 
-      rflib_StringUtil.replaceWithAllMaskingRules(messagesAsStr) :
-      messagesAsStr;
-    
-    Integer messageSize = maskedLogMessagesIfApplicable.length();
-    
-    // see https://github.com/j-fischer/rflib/issues/67
-    String requestId = Request.getCurrent().getRequestId();
-    if (requestId == null) {
-      requestId = 'NULL';
-    }
-
-    rflib_Log_Event__e eventToLog = new rflib_Log_Event__e(
-      Source_System_ID__c = UserInfo.getOrganizationId(),
-      Request_ID__c = requestId.substring(0, Math.min(requestId.length(), 40)),
-      Log_Level__c = logLevel.toString(),
-      Context__c = context.substring(0, Math.min(context.length(), 40)),
-      Platform_Info__c = getPlatformInformation(),
-      Log_Messages__c = messageSize < MAX_MESSAGE_SIZE
-        ? maskedLogMessagesIfApplicable 
-        : maskedLogMessagesIfApplicable.substring(messageSize - MAX_MESSAGE_SIZE)
-    );
-
-    if (batchReportingLogLevel.encompasses(logLevel)) {
-      BATCH_EXECUTOR.addEvent(eventToLog);
-    } else {
-      eventPublisher.publish(eventToLog);
-      
-      if (flushLogStackLevel.encompasses(logLevel)) {
-        LOG_STATEMENTS.clear();
-      }
-    }
-  }
-
-  private void logMessage(rflib_LogLevel logLevel, String message, Object[] args, Exception ex) {
-    
-    String messageToLog = DateTime.now().format('yyyy-MM-dd\'T\'HH:mm:ss') + '|' + logLevel + '|' + rflib_TraceId.value + '|' + context;
-    
-    messageToLog = args == null || args.isEmpty()
-      ? messageToLog + '|' + message
-      : messageToLog + '|' + String.format(message, args);
-
-    if (ex != null) {
-      messageToLog = messageToLog + '\nMessage: ' + ex.getMessage() + '\nStracktrace: ' + ex.getStackTraceString();
-    }
-
-    if (systemDebugLevel.encompasses(logLevel)) {
-      debugLogger.debug(logLevel.getLoggingLevel(), messageToLog);
-    }
-
-    if (!generalLogLevel.encompasses(logLevel)) {
-      return;
-    }
-
-    if (logMessages.size() >= logCacheSize) {
-      logMessages.remove(0);
-    }
-
-    logMessages.add(messageToLog);
-    
-    if (reportingLogLevel.encompasses(logLevel)) {
-      reportLogs(logLevel);
-    }
-  }
-
-  private String getPlatformInformation() {
-    if (String.isNotBlank(PLATFORM_INFO)) {
-      return PLATFORM_INFO;
-    }
-
-    Map<String, Object> platformInfo = new Map<String, Object>();
-    platformInfo.put('SOQL queries', Limits.getQueries());
-    platformInfo.put('Query Rows', Limits.getQueryRows());
-    platformInfo.put('SOSL Queries', Limits.getSoslQueries());
-    platformInfo.put('DML Statements', Limits.getDmlStatements());
-    platformInfo.put('DML Rows', Limits.getDmlRows());
-    platformInfo.put('CPU Time', Limits.getCpuTime());
-    platformInfo.put('Heap Size', Limits.getHeapSize());
-    platformInfo.put('Callouts', Limits.getCallouts());
-    platformInfo.put('Email Invocations', Limits.getEmailInvocations());
-    platformInfo.put('Future Calls', Limits.getFutureCalls());
-    platformInfo.put('Queueable Jobs', Limits.getQueueableJobs());
-    platformInfo.put('Mobile Apex Push Calls', Limits.getMobilePushApexCalls());
-    platformInfo.put('Publish Immediate DML', Limits.getPublishImmediateDML());
-    platformInfo.put('Database Time', Limits.getDatabaseTime());
-    platformInfo.put('Apex Curser Rows', Limits.getApexCursorRows());
-    platformInfo.put('Fetch Call on Apex Curser', Limits.getFetchCallsOnApexCursor());
-
-    return JSON.serialize(platformInfo);
-  }
-
-  public interface DebugLogger {
-    void debug(LoggingLevel level, String message);
-  }
-
-  public class SystemDebugLogger implements DebugLogger {
-    public void debug(LoggingLevel level, String message) {
-      System.debug(level, message);
-    }
-  }
-
-  public class LogEventPublisher implements rflib_EventPublisher {
-
-    private final rflib_EventPublisher eventBusPublisher = new rflib_EventBusPublisher();
-
-    public Integer getPublishingCounter() {
-      return eventBusPublisher.getPublishingCounter();
-    }
-
-    public Database.SaveResult publish(SObject evt) {
-      List<Database.SaveResult> result = publish(new List<SObject> { evt });
-      return result == null ? null : result[0];
-    }
-
-    public List<Database.SaveResult> publish(List<SObject> events) {
-      
-      List<rflib_Log_Event__e> eventsToPublish = new List<rflib_Log_Event__e>((List<rflib_Log_Event__e>) events);
-
-      Integer publishingLimitOrDefault = rflib_GlobalSettings.publishingLimitOrDefault != null 
-        ? rflib_GlobalSettings.publishingLimitOrDefault
-        : Limits.getLimitPublishImmediateDML();
-        
-      if (Limits.getPublishImmediateDML() == Limits.getLimitPublishImmediateDML()) {
-        System.debug(LoggingLevel.ERROR, 'RFLIB: PublishImmediateDML Governor Limit reached; failed to publish ' + JSON.serialize(events));
-        return null;
-      }
-
-      if (eventBusPublisher.getPublishingCounter() == publishingLimitOrDefault) {
-        System.debug(LoggingLevel.ERROR, 'RFLIB: Publish Immediate DML limit (' + publishingLimitOrDefault +') reached; failed to publish ' + JSON.serialize(events));
-        return null;
-      }
-      
-      List<Database.SaveResult> results = eventBusPublisher.publish(addLogEventIfLimitIsReached(eventsToPublish, publishingLimitOrDefault));
-      
-      for (Database.SaveResult result : results) {
-        if(!result.isSuccess()) {
-          System.debug(LoggingLevel.ERROR, JSON.serialize(result.getErrors()));
+        rflib_Logger_Settings__c settings = rflib_Logger_Settings__c.getInstance();
+        if (settings.Log_Size__c != null) {
+            logger.setLogCacheSize(Integer.valueOf(settings.Log_Size__c));
         }
-      }
 
-      return results;
+        if (String.isNotBlank(settings.General_Log_Level__c)) {
+            logger.setGeneralLogLevel(rflib_LogLevel.fromString(settings.General_Log_Level__c));
+        }
+
+        if (String.isNotBlank(settings.System_Debug_Log_Level__c)) {
+            logger.setSystemDebugLevel(rflib_LogLevel.fromString(settings.System_Debug_Log_Level__c));
+        }
+
+        if (String.isNotBlank(settings.Log_Event_Reporting_Level__c)) {
+            logger.setReportingLogLevel(rflib_LogLevel.fromString(settings.Log_Event_Reporting_Level__c));
+        }
+
+        if (String.isNotBlank(settings.Flush_Log_Cache_Level__c)) {
+            logger.setFlushLogCacheLevel(rflib_LogLevel.fromString(settings.Flush_Log_Cache_Level__c));
+        }
+
+        if (String.isNotBlank(settings.Batched_Log_Event_Reporting_Level__c)) {
+            logger.setBatchReportingLogLevel(rflib_LogLevel.fromString(settings.Batched_Log_Event_Reporting_Level__c));
+        }
+
+        if (String.isNotBlank(settings.Observability_Log_Level__c)) {
+            logger.setObservabilityLogLevel(rflib_LogLevel.fromString(settings.Observability_Log_Level__c));
+        }
+
+        logger.setLogMaskingState(settings.Enable_Log_Masking__c);
+
+        return logger;
     }
 
-    private List<rflib_Log_Event__e> addLogEventIfLimitIsReached(List<rflib_Log_Event__e> logEvents, Integer publishingLimitOrDefault) {
-      if (eventBusPublisher.getPublishingCounter() < (publishingLimitOrDefault - 1)) {
-        return logEvents;
-      }
-
-      String rflibInfoMessage = '>>>>> RFLIB: Publish Immediate DML limit (' + publishingLimitOrDefault +') reached; THIS IS THE LAST EVENT FOR THIS TRANSACTION  <<<<<\n\n';
-      String requestId = Request.getCurrent().getRequestId();
-      if (requestId == null) {
-        requestId = 'NULL';
-      }
-
-      logEvents.add(new rflib_Log_Event__e(
-        Request_ID__c = requestId.substring(0, Math.min(requestId.length(), 40)),
-        Log_Level__c = rflib_LogLevel.WARN.toString(),
-        Context__c = 'RFLIB_INTERNAL_WARNING',
-        Platform_Info__c = 'N/A',
-        Log_Messages__c = rflibInfoMessage
-      ));
-      
-      return logEvents;
-    }
-  }
-
-  public class BatchLogEventPublisher implements rflib_EventPublisher {
-
-    private Integer publishingCounter = 0;
-    
-    public Integer getPublishingCounter() {
-        return publishingCounter;
+    /**
+     * Create a default logger instance for the given context. Default values for the logger are:
+     *    - cache size: 100
+     *    - general log level: DEBUG
+     *    - system debug level: DEBUG
+     *    - reporting log level: WARN
+     *    - event publishing: immediate
+     *
+     * @param  context The context for this logger.
+     * @return         The new logger instance for the given context.
+     */
+    public static rflib_Logger create(String context) {
+        return create(context, false);
     }
 
-    public Database.SaveResult publish(SObject event) {
-      publishingCounter++;
-      BATCH_EXECUTOR.addEvent((rflib_Log_Event__e) event);
-      return null;
+    /**
+     * Create a default logger instance for the given context. Default values for the logger are:
+     *    - cache size: 100
+     *    - general log level: DEBUG
+     *    - system debug level: DEBUG
+     *    - reporting log level: WARN
+     *    - event publishing: immediate
+     *
+     * @param  context The context for this logger.
+     * @return         The new logger instance for the given context.
+     */
+    public static rflib_Logger createBatchedLogger(String context) {
+        return create(context, true);
     }
 
-    public List<Database.SaveResult> publish(List<SObject> events) {
-      publishingCounter++;
-      for (SObject event : events) {
-        BATCH_EXECUTOR.addEvent((rflib_Log_Event__e) event);
-      }
-      return null;
-    }
-  }
-
-  private class BatchLogEventExecutor implements Queueable {
-
-    private final rflib_EventPublisher eventBusPublisher = new rflib_EventBusPublisher(); 
-    
-    private rflib_Log_Event__e lastEventToBePublished;
-
-    public void addEvent(rflib_Log_Event__e event) {
-      lastEventToBePublished = event;
+    /**
+     * Create a default logger instance for the given context. Default values for the logger are:
+     *    - cache size: 100
+     *    - general log level: DEBUG
+     *    - system debug level: DEBUG
+     *    - reporting log level: WARN
+     *    - event publishing: immediate
+     *
+     * @param  context The context for this logger.
+     * @param  shouldBatchEvents `Boolean` flag to indicate whether to publish events in batch or not. Batched events will require the invocation of `rflib_Logger.publishBatchedLogEvents()` to be dispatched.
+     * @return         The new logger instance for the given context.
+     */
+    public static rflib_Logger create(String context, Boolean shouldBatchEvents) {
+        return new rflib_DefaultLogger(context, shouldBatchEvents);
     }
 
-    public void execute(QueueableContext ctx) {
-      if (lastEventToBePublished == null) {
-        System.debug(LoggingLevel.INFO, 'There is no log event to be published; exiting.');
-        return;
-      }
-      Database.SaveResult result = eventBusPublisher.publish(lastEventToBePublished);
-      
-      if(!result.isSuccess()) {
-        System.debug(LoggingLevel.ERROR, JSON.serialize(result.getErrors()));
-      }
+    private rflib_DefaultLogger(String context, Boolean shouldBatchEvents) {
+        this(
+            shouldBatchEvents
+                ? (rflib_EventPublisher) new rflib_DefaultLogger.BatchLogEventPublisher()
+                : (rflib_EventPublisher) new rflib_DefaultLogger.LogEventPublisher(),
+            new rflib_DefaultLogger.SystemDebugLogger(),
+            context
+        );
     }
-  }
+
+    @TestVisible
+    private rflib_DefaultLogger(
+        rflib_EventPublisher eventPublisher,
+        rflib_DefaultLogger.DebugLogger debugLogger,
+        String context
+    ) {
+        this(eventPublisher, debugLogger, context, LOG_STATEMENTS);
+    }
+
+    private rflib_DefaultLogger(
+        rflib_EventPublisher eventPublisher,
+        rflib_DefaultLogger.DebugLogger debugLogger,
+        String context,
+        List<String> logMessages
+    ) {
+        this.eventPublisher = eventPublisher;
+        this.debugLogger = debugLogger;
+        this.context = context;
+        this.logMessages = logMessages;
+    }
+
+    public void setLogCacheSize(Integer newSize) {
+        logCacheSize = newSize;
+
+        Integer numberOfCollectedMessages = logMessages.size();
+        if (numberOfCollectedMessages > newSize) {
+            for (Integer i = 0; i < (numberOfCollectedMessages - newSize); i++) {
+                logMessages.remove(0);
+            }
+        }
+    }
+
+    public void setReportingLogLevel(rflib_LogLevel newLevel) {
+        // NOTE: The reporting level can only be INFO or higher to prevent accidental
+        //       "floods" of Log Events being created. Following best practices, DEBUG and TRACE statements
+        //       should be used within loops and should ideally never cause a Log Event to be sent out.
+        //       It is recommended that most log statements should be INFO level to provide the most transparency
+        //       when reducing the reporting log level down to INFO.
+        //       See https://github.com/j-fischer/rflib/issues/6 for more details.
+        reportingLogLevel = rflib_LogLevel.INFO.encompasses(newLevel) || rflib_LogLevel.NONE == newLevel
+            ? newLevel
+            : rflib_LogLevel.INFO;
+    }
+
+    public void setFlushLogCacheLevel(rflib_LogLevel newLevel) {
+        // NOTE: Because this log level is aligned with the reporting log level, the same restrictions
+        //       apply with respect to the supported levels.
+        flushLogStackLevel = rflib_LogLevel.INFO.encompasses(newLevel) || rflib_LogLevel.NONE == newLevel
+            ? newLevel
+            : rflib_LogLevel.INFO;
+    }
+
+    public void setBatchReportingLogLevel(rflib_LogLevel newLevel) {
+        batchReportingLogLevel = newLevel;
+    }
+
+    public void setSystemDebugLevel(rflib_LogLevel newLevel) {
+        systemDebugLevel = newLevel;
+    }
+
+    public void setGeneralLogLevel(rflib_LogLevel newLevel) {
+        generalLogLevel = newLevel;
+    }
+
+    public void setLogMaskingState(Boolean isEnabled) {
+        isLogMaskingEnabled = isEnabled;
+    }
+
+    public void setObservabilityLogLevel(rflib_LogLevel newLevel) {
+        // NOTE: The observability level can only be WARN or higher to prevent accidental
+        //       "floods" of Application Events being created. Following best practices, DEBUG and TRACE statements
+        //       should be used within loops and should ideally never cause a Log Event to be sent out.
+        //       It is recommended that most log statements should be INFO level to provide the most transparency
+        //       for logging purposes, while the observability has the focus to highlight issues in the application.
+        observabilityLogLevel = rflib_LogLevel.WARN.encompasses(newLevel) || rflib_LogLevel.NONE == newLevel
+            ? newLevel
+            : rflib_LogLevel.WARN;
+    }
+
+    public void setPlatformInfo(String platformInfo) {
+        PLATFORM_INFO = platformInfo;
+    }
+
+    public void trace(String message) {
+        trace(message, null);
+    }
+
+    public void trace(String message, Object[] args) {
+        logMessage(rflib_LogLevel.TRACE, message, args, null);
+    }
+
+    public void debug(String message) {
+        debug(message, null);
+    }
+
+    public void debug(String message, Object[] args) {
+        logMessage(rflib_LogLevel.DEBUG, message, args, null);
+    }
+
+    public void info(String message) {
+        info(message, null);
+    }
+
+    public void info(String message, Object[] args) {
+        logMessage(rflib_LogLevel.INFO, message, args, null);
+    }
+
+    public void warn(String message) {
+        warn(message, null);
+    }
+
+    public void warn(String message, Object[] args) {
+        logMessage(rflib_LogLevel.WARN, message, args, null);
+    }
+
+    public void error(String message) {
+        error(message, null, null);
+    }
+
+    public void error(String message, Exception ex) {
+        error(message, null, ex);
+    }
+
+    public void error(String message, Object[] args) {
+        error(message, args, null);
+    }
+
+    public void error(String message, Object[] args, Exception ex) {
+        logMessage(rflib_LogLevel.ERROR, message, args, ex);
+    }
+
+    public void fatal(String message) {
+        fatal(message, null, null);
+    }
+
+    public void fatal(String message, Exception ex) {
+        fatal(message, null, ex);
+    }
+
+    public void fatal(String message, Object[] args) {
+        fatal(message, args, null);
+    }
+
+    public void fatal(String message, Object[] args, Exception ex) {
+        logMessage(rflib_LogLevel.FATAL, message, args, ex);
+    }
+
+    public String printLogs() {
+        String logMessages = 'Log statements reported by ' + context + ':\n' + String.join(logMessages, '\n');
+        debugLogger.debug(LoggingLevel.DEBUG, logMessages);
+        return logMessages;
+    }
+
+    public void reportLogs() {
+        reportLogs(rflib_LogLevel.DEBUG);
+    }
+
+    public void publishBatchedLogEvents() {
+        if (Limits.getDmlStatements() < Limits.getLimitDmlStatements()) {
+            BATCH_EXECUTOR.execute(null);
+        } else {
+            System.enqueueJob(BATCH_EXECUTOR);
+        }
+
+        BATCH_EXECUTOR = new rflib_DefaultLogger.BatchLogEventExecutor();
+    }
+
+    private void reportLogs(rflib_LogLevel logLevel) {
+        String messagesAsStr = String.join(logMessages, '\n');
+
+        // It is important to run the masking rules first as those could change the size of the string, possibly making it larger.
+        String maskedLogMessagesIfApplicable = isLogMaskingEnabled
+            ? rflib_StringUtil.replaceWithAllMaskingRules(messagesAsStr)
+            : messagesAsStr;
+
+        Integer messageSize = maskedLogMessagesIfApplicable.length();
+
+        // see https://github.com/j-fischer/rflib/issues/67
+        String requestId = Request.getCurrent().getRequestId();
+        if (requestId == null) {
+            requestId = 'NULL';
+        }
+
+        String logMessageToPublish = messageSize < MAX_MESSAGE_SIZE
+            ? maskedLogMessagesIfApplicable
+            : maskedLogMessagesIfApplicable.substring(messageSize - MAX_MESSAGE_SIZE);
+
+        List<SObject> platformEventsToLog = new List<SObject>();
+
+        rflib_Log_Event__e eventToLog = new rflib_Log_Event__e(
+            Source_System_ID__c = UserInfo.getOrganizationId(),
+            Request_ID__c = requestId.substring(0, Math.min(requestId.length(), 40)),
+            Log_Level__c = logLevel.toString(),
+            Context__c = context.substring(0, Math.min(context.length(), 40)),
+            Platform_Info__c = getPlatformInformation(),
+            Log_Messages__c = logMessageToPublish
+        );
+
+        platformEventsToLog.add(eventToLog);
+
+        if (observabilityLogLevel.encompasses(logLevel)) {
+            String eventName = String.format(
+                APPLICATION_EVENT_NAME_PATTERN,
+                new List<String>{ logLevel.toString().toLowerCase(), context }
+            );
+            rflib_Application_Event_Occurred_Event__e appEventToLog = new rflib_Application_Event_Occurred_Event__e(
+                Event_Name__c = eventName,
+                Occurred_On__c = DateTime.now(),
+                Related_Record_ID__c = rflib_DefaultApplicationEventService.NO_RECORD_ID,
+                Additional_Details__c = logMessageToPublish,
+                Created_By_ID__c = UserInfo.getUserId()
+            );
+
+            platformEventsToLog.add(appEventToLog);
+        }
+
+        if (batchReportingLogLevel.encompasses(logLevel)) {
+            BATCH_EXECUTOR.addEvent(platformEventsToLog);
+        } else {
+            eventPublisher.publish(platformEventsToLog);
+
+            if (flushLogStackLevel.encompasses(logLevel)) {
+                LOG_STATEMENTS.clear();
+            }
+        }
+    }
+
+    private void logMessage(rflib_LogLevel logLevel, String message, Object[] args, Exception ex) {
+        String messageToLog =
+            DateTime.now().format('yyyy-MM-dd\'T\'HH:mm:ss') +
+            '|' +
+            logLevel +
+            '|' +
+            rflib_TraceId.value +
+            '|' +
+            context;
+
+        messageToLog = args == null || args.isEmpty()
+            ? messageToLog + '|' + message
+            : messageToLog + '|' + String.format(message, args);
+
+        if (ex != null) {
+            messageToLog =
+                messageToLog +
+                '\nMessage: ' +
+                ex.getMessage() +
+                '\nStracktrace: ' +
+                ex.getStackTraceString();
+        }
+
+        if (systemDebugLevel.encompasses(logLevel)) {
+            debugLogger.debug(logLevel.getLoggingLevel(), messageToLog);
+        }
+
+        if (!generalLogLevel.encompasses(logLevel)) {
+            return;
+        }
+
+        if (logMessages.size() >= logCacheSize) {
+            logMessages.remove(0);
+        }
+
+        logMessages.add(messageToLog);
+
+        if (reportingLogLevel.encompasses(logLevel)) {
+            reportLogs(logLevel);
+        }
+    }
+
+    private String getPlatformInformation() {
+        if (String.isNotBlank(PLATFORM_INFO)) {
+            return PLATFORM_INFO;
+        }
+
+        Map<String, Object> platformInfo = new Map<String, Object>();
+        platformInfo.put('SOQL queries', Limits.getQueries());
+        platformInfo.put('Query Rows', Limits.getQueryRows());
+        platformInfo.put('SOSL Queries', Limits.getSoslQueries());
+        platformInfo.put('DML Statements', Limits.getDmlStatements());
+        platformInfo.put('DML Rows', Limits.getDmlRows());
+        platformInfo.put('CPU Time', Limits.getCpuTime());
+        platformInfo.put('Heap Size', Limits.getHeapSize());
+        platformInfo.put('Callouts', Limits.getCallouts());
+        platformInfo.put('Email Invocations', Limits.getEmailInvocations());
+        platformInfo.put('Future Calls', Limits.getFutureCalls());
+        platformInfo.put('Queueable Jobs', Limits.getQueueableJobs());
+        platformInfo.put('Mobile Apex Push Calls', Limits.getMobilePushApexCalls());
+        platformInfo.put('Publish Immediate DML', Limits.getPublishImmediateDML());
+        platformInfo.put('Database Time', Limits.getDatabaseTime());
+        platformInfo.put('Apex Curser Rows', Limits.getApexCursorRows());
+        platformInfo.put('Fetch Call on Apex Curser', Limits.getFetchCallsOnApexCursor());
+
+        return JSON.serialize(platformInfo);
+    }
+
+    public interface DebugLogger {
+        void debug(LoggingLevel level, String message);
+    }
+
+    public class SystemDebugLogger implements DebugLogger {
+        public void debug(LoggingLevel level, String message) {
+            System.debug(level, message);
+        }
+    }
+
+    public class LogEventPublisher implements rflib_EventPublisher {
+        private final rflib_EventPublisher eventBusPublisher = new rflib_EventBusPublisher();
+
+        public Integer getPublishingCounter() {
+            return eventBusPublisher.getPublishingCounter();
+        }
+
+        public Database.SaveResult publish(SObject evt) {
+            List<Database.SaveResult> result = publish(new List<SObject>{ evt });
+            return result == null ? null : result[0];
+        }
+
+        public List<Database.SaveResult> publish(List<SObject> events) {
+            Integer publishingLimitOrDefault = rflib_GlobalSettings.publishingLimitOrDefault != null
+                ? rflib_GlobalSettings.publishingLimitOrDefault
+                : Limits.getLimitPublishImmediateDML();
+
+            if (Limits.getPublishImmediateDML() == Limits.getLimitPublishImmediateDML()) {
+                System.debug(
+                    LoggingLevel.ERROR,
+                    'RFLIB: PublishImmediateDML Governor Limit reached; failed to publish ' + JSON.serialize(events)
+                );
+                return null;
+            }
+
+            if (eventBusPublisher.getPublishingCounter() == publishingLimitOrDefault) {
+                System.debug(
+                    LoggingLevel.ERROR,
+                    'RFLIB: Publish Immediate DML limit (' +
+                        publishingLimitOrDefault +
+                        ') reached; failed to publish ' +
+                        JSON.serialize(events)
+                );
+                return null;
+            }
+
+            // IMPORTANT: When using a List<SObject> for publishing a platform event within a read-only transaction (i.e. cacheable=true)
+            // Salesforce will automatically assume that the events are not published immediately and consume a DML operation for the request.
+            // Casting a list to a specific event allows Salesforce to infer that the event is published immediately, which will not cause a runtime exception.
+            List<rflib_Log_Event__e> logEventsToPublish = new List<rflib_Log_Event__e>();
+            List<rflib_Application_Event_Occurred_Event__e> appEventsToPublish = new List<rflib_Application_Event_Occurred_Event__e>();
+
+            for (SObject evt : events) {
+                Schema.SObjectType evtType = evt.getSObjectType();
+
+                if (evtType == rflib_Log_Event__e.SObjectType) {
+                    logEventsToPublish.add((rflib_Log_Event__e) evt);
+                } else if (evtType == rflib_Application_Event_Occurred_Event__e.SObjectType) {
+                    appEventsToPublish.add((rflib_Application_Event_Occurred_Event__e) evt);
+                } else {
+                    System.debug('Unhandled event type: ' + evtType.getDescribe().getName());
+                }
+            }
+
+            List<Database.SaveResult> results = new List<Database.SaveResult>();
+            results.addAll(
+                eventBusPublisher.publish(addLogEventIfLimitIsReached(logEventsToPublish, publishingLimitOrDefault))
+            );
+            if (appEventsToPublish.size() > 0) {
+                if (Limits.getPublishImmediateDML() == Limits.getLimitPublishImmediateDML()) {
+                    System.debug(
+                        LoggingLevel.ERROR,
+                        'RFLIB: PublishImmediateDML Governor Limit reached; failed to publish ' +
+                        JSON.serialize(appEventsToPublish)
+                    );
+                } else {
+                    results.addAll(eventBusPublisher.publish(appEventsToPublish));
+                }
+            }
+
+            for (Database.SaveResult result : results) {
+                if (!result.isSuccess()) {
+                    System.debug(LoggingLevel.ERROR, JSON.serialize(result.getErrors()));
+                }
+            }
+
+            return results;
+        }
+
+        private List<SObject> addLogEventIfLimitIsReached(List<SObject> logEvents, Integer publishingLimitOrDefault) {
+            if (eventBusPublisher.getPublishingCounter() < (publishingLimitOrDefault - 1)) {
+                return logEvents;
+            }
+
+            String rflibInfoMessage =
+                '>>>>> RFLIB: Publish Immediate DML limit (' +
+                publishingLimitOrDefault +
+                ') reached; THIS IS THE LAST EVENT FOR THIS TRANSACTION  <<<<<\n\n';
+            String requestId = Request.getCurrent().getRequestId();
+            if (requestId == null) {
+                requestId = 'NULL';
+            }
+
+            logEvents.add(
+                new rflib_Log_Event__e(
+                    Request_ID__c = requestId.substring(0, Math.min(requestId.length(), 40)),
+                    Log_Level__c = rflib_LogLevel.WARN.toString(),
+                    Context__c = 'RFLIB_INTERNAL_WARNING',
+                    Platform_Info__c = 'N/A',
+                    Log_Messages__c = rflibInfoMessage
+                )
+            );
+
+            return logEvents;
+        }
+    }
+
+    public class BatchLogEventPublisher implements rflib_EventPublisher {
+        private Integer publishingCounter = 0;
+
+        public Integer getPublishingCounter() {
+            return publishingCounter;
+        }
+
+        public Database.SaveResult publish(SObject event) {
+            publishingCounter++;
+            BATCH_EXECUTOR.addEvent((rflib_Log_Event__e) event);
+            return null;
+        }
+
+        public List<Database.SaveResult> publish(List<SObject> events) {
+            publishingCounter++;
+            for (SObject event : events) {
+                BATCH_EXECUTOR.addEvent((rflib_Log_Event__e) event);
+            }
+            return null;
+        }
+    }
+
+    private class BatchLogEventExecutor implements Queueable {
+        private final rflib_EventPublisher eventBusPublisher = new rflib_EventBusPublisher();
+
+        private List<SObject> allEventsToBePublished = new List<SObject>();
+
+        private rflib_Log_Event__e lastEventToBePublished;
+
+        public void addEvent(rflib_Log_Event__e event) {
+            lastEventToBePublished = event;
+        }
+
+        public void addEvent(List<SObject> platformEvents) {
+            for (SObject pe : platformEvents) {
+                if (pe instanceof rflib_Log_Event__e) {
+                    addEvent((rflib_Log_Event__e) pe);
+                } else {
+                    allEventsToBePublished.add(pe);
+                }
+            }
+        }
+
+        public void execute(QueueableContext ctx) {
+            if (lastEventToBePublished == null) {
+                System.debug(LoggingLevel.INFO, 'There is no log event to be published; exiting.');
+                return;
+            }
+            Database.SaveResult result = eventBusPublisher.publish(lastEventToBePublished);
+
+            if (!result.isSuccess()) {
+                System.debug(LoggingLevel.ERROR, JSON.serialize(result.getErrors()));
+            }
+        }
+    }
 }

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -59,7 +59,7 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
     private rflib_LogLevel reportingLogLevel = rflib_LogLevel.WARN;
     private rflib_LogLevel flushLogStackLevel = rflib_LogLevel.NONE;
     private rflib_LogLevel batchReportingLogLevel = rflib_LogLevel.NONE;
-    private rflib_LogLevel observabilityLogLevel = rflib_LogLevel.NONE;
+    private rflib_LogLevel logAggregationLogLevel = rflib_LogLevel.NONE;
 
     /**
      * DEPRECATED - Use `new rflib_DefaultLoggerFactory.createLogger()` instead.
@@ -126,8 +126,8 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
             logger.setBatchReportingLogLevel(rflib_LogLevel.fromString(settings.Batched_Log_Event_Reporting_Level__c));
         }
 
-        if (String.isNotBlank(settings.Observability_Log_Level__c)) {
-            logger.setObservabilityLogLevel(rflib_LogLevel.fromString(settings.Observability_Log_Level__c));
+        if (String.isNotBlank(settings.Log_Aggregation_Log_Level__c)) {
+            logger.setLogAggregationLogLevel(rflib_LogLevel.fromString(settings.Log_Aggregation_Log_Level__c));
         }
 
         logger.setLogMaskingState(settings.Enable_Log_Masking__c);
@@ -259,13 +259,13 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
         isLogMaskingEnabled = isEnabled;
     }
 
-    public void setObservabilityLogLevel(rflib_LogLevel newLevel) {
+    public void setLogAggregationLogLevel(rflib_LogLevel newLevel) {
         // NOTE: The observability level can only be WARN or higher to prevent accidental
         //       "floods" of Application Events being created. Following best practices, DEBUG and TRACE statements
         //       should be used within loops and should ideally never cause a Log Event to be sent out.
         //       It is recommended that most log statements should be INFO level to provide the most transparency
         //       for logging purposes, while the observability has the focus to highlight issues in the application.
-        observabilityLogLevel = rflib_LogLevel.WARN.encompasses(newLevel) || rflib_LogLevel.NONE == newLevel
+        logAggregationLogLevel = rflib_LogLevel.WARN.encompasses(newLevel) || rflib_LogLevel.NONE == newLevel
             ? newLevel
             : rflib_LogLevel.WARN;
     }
@@ -391,7 +391,7 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
 
         platformEventsToLog.add(eventToLog);
 
-        if (observabilityLogLevel.encompasses(logLevel)) {
+        if (logAggregationLogLevel.encompasses(logLevel)) {
             String eventName = String.format(
                 APPLICATION_EVENT_NAME_PATTERN,
                 new List<String>{ logLevel.toString().toLowerCase(), context }

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls
@@ -59,7 +59,7 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
     private rflib_LogLevel reportingLogLevel = rflib_LogLevel.WARN;
     private rflib_LogLevel flushLogStackLevel = rflib_LogLevel.NONE;
     private rflib_LogLevel batchReportingLogLevel = rflib_LogLevel.NONE;
-    private rflib_LogLevel observabilityLogLevel = rflib_LogLevel.ERROR;
+    private rflib_LogLevel observabilityLogLevel = rflib_LogLevel.NONE;
 
     /**
      * DEPRECATED - Use `new rflib_DefaultLoggerFactory.createLogger()` instead.
@@ -555,7 +555,7 @@ public without sharing class rflib_DefaultLogger implements rflib_Logger {
                 eventBusPublisher.publish(addLogEventIfLimitIsReached(logEventsToPublish, publishingLimitOrDefault))
             );
             if (appEventsToPublish.size() > 0) {
-                if (Limits.getPublishImmediateDML() == Limits.getLimitPublishImmediateDML()) {
+                if (Limits.getPublishImmediateDML() == Limits.getLimitPublishImmediateDML() || eventBusPublisher.getPublishingCounter() == publishingLimitOrDefault) {
                     System.debug(
                         LoggingLevel.ERROR,
                         'RFLIB: PublishImmediateDML Governor Limit reached; failed to publish ' +

--- a/rflib/main/default/classes/rflib_Logger.cls
+++ b/rflib/main/default/classes/rflib_Logger.cls
@@ -113,6 +113,16 @@ public interface rflib_Logger {
    * @param  isEnabled The new state whether log masking is enabled or not.
    */
   void setLogMaskingState(Boolean isEnabled);
+
+  /**
+    * Set the log level for when Application Events should be created.
+    * Only WARN, ERROR and FATAL are valid values.
+    * 
+    * rflib_DefaultLogger's default level is ERROR.
+    *
+    * @param  newLevel The new log level to be used for observability. 
+    */
+  void setObservabilityLogLevel(rflib_LogLevel newLevel);
   
   /**
    * Override the platform information to be sent with any log event for this transaction. 

--- a/rflib/main/default/classes/rflib_Logger.cls
+++ b/rflib/main/default/classes/rflib_Logger.cls
@@ -122,7 +122,7 @@ public interface rflib_Logger {
     *
     * @param  newLevel The new log level to be used for observability. 
     */
-  void setObservabilityLogLevel(rflib_LogLevel newLevel);
+  void setLogAggregationLogLevel(rflib_LogLevel newLevel);
   
   /**
    * Override the platform information to be sent with any log event for this transaction. 

--- a/rflib/main/default/classes/rflib_Logger.cls
+++ b/rflib/main/default/classes/rflib_Logger.cls
@@ -118,7 +118,7 @@ public interface rflib_Logger {
     * Set the log level for when Application Events should be created.
     * Only WARN, ERROR and FATAL are valid values.
     * 
-    * rflib_DefaultLogger's default level is ERROR.
+    * rflib_DefaultLogger's default level is NONE.
     *
     * @param  newLevel The new log level to be used for observability. 
     */

--- a/rflib/main/default/lwc/rflibLogEventMonitor/rflibLogEventMonitor.js
+++ b/rflib/main/default/lwc/rflibLogEventMonitor/rflibLogEventMonitor.js
@@ -132,9 +132,15 @@ export default class LogEventMonitor extends LightningElement {
             });
         }
 
-        subscribe(CHANNEL, this.currentConnectionMode.value, this.messageCallback).then(
-            _this.createSubscriptionResponseHandler(this)
-        );
+        subscribe(CHANNEL, this.currentConnectionMode.value, this.messageCallback).then(() => {
+            _this.createSubscriptionResponseHandler(this);
+            const evt = new ShowToastEvent({
+                title: 'Connection Mode Changed',
+                message: 'You are now connected to receive ' + _this.currentConnectionMode.label,
+                variant: 'success'
+            });
+            _this.dispatchEvent(evt);
+        });
     }
 
     disconnectedCallback() {
@@ -152,11 +158,19 @@ export default class LogEventMonitor extends LightningElement {
         logger.debug(
             'Connection Mode changed: newConnectionMode={0}, currentConnectionMode={1}',
             newConnectionMode,
-            this.currentConnectionMode.value
+            _this.currentConnectionMode.value
         );
 
         if (newConnectionMode > 0) {
-            this.disconnectedCallback();
+            _this.disconnectedCallback();
+
+            _this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Disconnected from event channel',
+                    message: 'You are no longer receiving any log events.',
+                    variant: 'warn'
+                })
+            );
 
             const args = {
                 startDate: this.startDate,
@@ -189,6 +203,8 @@ export default class LogEventMonitor extends LightningElement {
                     });
                     this.dispatchEvent(evt);
                 });
+
+            return;
         }
 
         const connectToServer = function () {
@@ -204,12 +220,24 @@ export default class LogEventMonitor extends LightningElement {
                 }
 
                 logger.debug('this.currentConnectionMode: ' + JSON.stringify(_this.currentConnectionMode));
-                subscribe(CHANNEL, _this.currentConnectionMode.value, _this.messageCallback).then(
-                    _this.createSubscriptionResponseHandler(_this)
-                );
+                subscribe(CHANNEL, _this.currentConnectionMode.value, _this.messageCallback).then(() => {
+                    _this.createSubscriptionResponseHandler(_this);
+                    const evt = new ShowToastEvent({
+                        title: 'Connection Mode Changed',
+                        message: 'You are now connected to receive ' + _this.currentConnectionMode.label,
+                        variant: 'success'
+                    });
+                    _this.dispatchEvent(evt);
+                });
             } else {
                 logger.debug('Connection deactivated');
                 _this.currentConnectionMode = CONNECTION_MODE.DISCONNECTED;
+                const evt = new ShowToastEvent({
+                    title: 'Disconnected from event channel',
+                    message: 'You are no longer receiving any log events.',
+                    variant: 'warn'
+                });
+                _this.dispatchEvent(evt);
             }
         };
 

--- a/rflib/main/default/lwc/rflibUserPermissionSetManager/rflibUserPermissionSetManager.js
+++ b/rflib/main/default/lwc/rflibUserPermissionSetManager/rflibUserPermissionSetManager.js
@@ -38,7 +38,7 @@ import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 
 import { createLogger } from 'c/rflibLogger';
 
-const logger = createLogger('UserPermissionSetManager');
+const logger = createLogger('rflibUserPermissionSetManager');
 
 export default class RflibUserPermissionSetManager extends LightningElement {
     _wireUserPermissionResult;

--- a/rflib/main/default/objects/rflib_Logger_Settings__c/fields/Log_Aggregation_Log_Level__c.field-meta.xml
+++ b/rflib/main/default/objects/rflib_Logger_Settings__c/fields/Log_Aggregation_Log_Level__c.field-meta.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Observability_Log_Level__c</fullName>
+    <fullName>Log_Aggregation_Log_Level__c</fullName>
     <defaultValue>&quot;NONE&quot;</defaultValue>
     <description>The log level at which Application Events will be created. Must be one of: WARN, ERROR, or FATAL.</description>
     <externalId>false</externalId>
     <inlineHelpText>The log level at which Application Events will be created. Must be one of: WARN, ERROR, or FATAL.</inlineHelpText>
-    <label>Observability Log Level</label>
+    <label>Log Aggregation Log Level</label>
     <length>5</length>
     <required>true</required>
     <trackTrending>false</trackTrending>

--- a/rflib/main/default/objects/rflib_Logger_Settings__c/fields/Observability_Log_Level__c.field-meta.xml
+++ b/rflib/main/default/objects/rflib_Logger_Settings__c/fields/Observability_Log_Level__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Observability_Log_Level__c</fullName>
+    <defaultValue>&quot;NONE&quot;</defaultValue>
+    <description>The log level at which Application Events will be created. Must be one of: WARN, ERROR, or FATAL.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The log level at which Application Events will be created. Must be one of: WARN, ERROR, or FATAL.</inlineHelpText>
+    <label>Observability Log Level</label>
+    <length>5</length>
+    <required>true</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
+++ b/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
@@ -29,462 +29,694 @@
 @isTest
 @SuppressWarnings('PMD.ClassNamingConventions')
 public class rflib_DefaultLoggerTest {
+    private static final String ABORT_TRANSACTION = 'Abort Transaction';
 
-  private static final String ABORT_TRANSACTION = 'Abort Transaction';
+    private static final String AFTER_INSERT = TriggerOperation.AFTER_INSERT.name();
+    private static final String OBJECT_TYPE_NAME = rflib_Log_Event__e.SObjectType.getDescribe().getName();
 
-  private static final String AFTER_INSERT = TriggerOperation.AFTER_INSERT.name();
-  private static final String OBJECT_TYPE_NAME = rflib_Log_Event__e.SObjectType.getDescribe().getName();
+    @isTest
+    public static void testDefaultBehaviour() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
 
-  @isTest
-  public static void testDefaultBehaviour() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+        rflib_Logger logger = loggerFactory.createLogger('testDefaultBehaviour');
 
-    rflib_Logger logger = loggerFactory.createLogger('testDefaultBehaviour');
+        createLogStatements(loggerFactory, logger);
 
-    createLogStatements(loggerFactory, logger);
+        logger.printLogs();
 
-    logger.printLogs();
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('Log statements reported by'),
+            'debugLogger did not contain header statement'
+        );
+        System.assert(
+            loggerFactory.debugLogCapture.doesNotContainInAnyMessage('first info statement'),
+            'debugLogger falsely contained statement'
+        );
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('warn statement'),
+            'debugLogger did not contain statement'
+        );
 
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('Log statements reported by'), 'debugLogger did not contain header statement'); 
-    System.assert(loggerFactory.debugLogCapture.doesNotContainInAnyMessage('first info statement'), 'debugLogger falsely contained statement');
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('warn statement'), 'debugLogger did not contain statement');
+        logger.fatal('fatal log statement');
 
-    logger.fatal('fatal log statement');
-
-    System.assert(loggerFactory.eventCapture.eventHasBeenPublished(), 'event did not get published');
-    System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('first info statement'), 'event falsely contained statement');
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('warn statement'), 'event did not contain statement');
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('fatal log statement'), 'event did not contain statement');
-  }
-
-  @isTest
-  public static void testSetLogCacheSize() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-
-    rflib_Logger logger = loggerFactory.createLogger('testSetLogCacheSize');
-
-    logger.setLogCacheSize(3);
-
-    logger.info('first info statement');
-
-    Integer i;
-    for (i = 2; i < 5; i++) {
-      logger.info('info statement ' + i);
+        System.assert(loggerFactory.eventCapture.eventHasBeenPublished(), 'event did not get published');
+        System.assert(
+            loggerFactory.eventCapture.doesNotContainInAnyMessage('first info statement'),
+            'event falsely contained statement'
+        );
+        System.assert(
+            loggerFactory.eventCapture.containsInAnyMessage('warn statement'),
+            'event did not contain statement'
+        );
+        System.assert(
+            loggerFactory.eventCapture.containsInAnyMessage('fatal log statement'),
+            'event did not contain statement'
+        );
     }
 
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('first info statement'), 'debugLogger did not contain statement');
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('info statement 4'), 'debugLogger did not contain statement');
+    @isTest
+    public static void testSetLogCacheSize() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
 
-    loggerFactory.debugLogCapture.clearCapturedLogs();
-    logger.printLogs();
+        rflib_Logger logger = loggerFactory.createLogger('testSetLogCacheSize');
 
-    System.assert(loggerFactory.debugLogCapture.doesNotContainInAnyMessage('first info statement'), 'debugLogger falsely contained statement');
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('info statement 4'), 'debugLogger did not contain statement');
+        logger.setLogCacheSize(3);
 
-    logger.fatal('fatal log statement');
+        logger.info('first info statement');
 
-    System.assert(loggerFactory.eventCapture.eventHasBeenPublished(), 'event did not get published');
-    System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('first info statement'), 'event falsely contained statement');
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('fatal log statement'), 'event did not contain statement');
-  }
+        Integer i;
+        for (i = 2; i < 5; i++) {
+            logger.info('info statement ' + i);
+        }
 
-  @isTest
-  public static void testSetSystemLoggingLevel() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('first info statement'),
+            'debugLogger did not contain statement'
+        );
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('info statement 4'),
+            'debugLogger did not contain statement'
+        );
 
-    rflib_Logger logger = loggerFactory.createLogger('testSetLogCacheSize');
+        loggerFactory.debugLogCapture.clearCapturedLogs();
+        logger.printLogs();
 
-    logger.trace('trace statement to ignore');
-    System.assert(loggerFactory.debugLogCapture.doesNotContainInAnyMessage('trace statement to ignore'), 'falsely contained debug statement to ignore');
+        System.assert(
+            loggerFactory.debugLogCapture.doesNotContainInAnyMessage('first info statement'),
+            'debugLogger falsely contained statement'
+        );
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('info statement 4'),
+            'debugLogger did not contain statement'
+        );
 
-    logger.setSystemDebugLevel(rflib_LogLevel.TRACE);
+        logger.fatal('fatal log statement');
 
-    logger.trace('trace statement to include');
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('trace statement to include'), 'debugLogger did not contain statement');
-  }
-
-  @isTest
-  public static void testSetReportingLogLevel() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-
-    rflib_Logger logger = loggerFactory.createLogger('testSetReportingLogLevel');
-
-    logger.info('This statement should NOT trigger the publishing of an event');
-    System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
-
-    logger.setReportingLogLevel(rflib_LogLevel.INFO);
-
-    logger.info('This statement should trigger the publishing of an event');
-    System.assert(loggerFactory.eventCapture.eventHasBeenPublished());
-  }
-
-  @isTest
-  public static void testSetReportingLogLevel_LevelCannotBeSetBelowInfo() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-
-    rflib_Logger logger = loggerFactory.createLogger('testSetReportingLogLevel_LevelCannotBeSetBelowInfo');
-
-    // This will set the actual log level to INFO
-    logger.setReportingLogLevel(rflib_LogLevel.DEBUG);
-
-    logger.debug('This statement should NOT trigger the publishing of an event');
-    System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
-
-    logger.info('This statement should trigger the publishing of an event');
-    System.assert(loggerFactory.eventCapture.eventHasBeenPublished());
-  }
-
-  @isTest
-  public static void testExceedMaxMessageSize() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-
-    rflib_Logger logger = loggerFactory.createLogger('testSetReportingLogLevel');
-
-    logger.setReportingLogLevel(rflib_LogLevel.ERROR);
-
-    String longMessage = 'a';
-    for (Integer i = 1; i < rflib_DefaultLogger.MAX_MESSAGE_SIZE; i++) {
-      longMessage += 'b';
+        System.assert(loggerFactory.eventCapture.eventHasBeenPublished(), 'event did not get published');
+        System.assert(
+            loggerFactory.eventCapture.doesNotContainInAnyMessage('first info statement'),
+            'event falsely contained statement'
+        );
+        System.assert(
+            loggerFactory.eventCapture.containsInAnyMessage('fatal log statement'),
+            'event did not contain statement'
+        );
     }
 
-    longMessage += 'c';
+    @isTest
+    public static void testSetSystemLoggingLevel() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
 
-    logger.error(longMessage);
+        rflib_Logger logger = loggerFactory.createLogger('testSetLogCacheSize');
 
-    System.assert(loggerFactory.eventCapture.eventHasBeenPublished());
-    System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('a'));
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('c'));
-  }
+        logger.trace('trace statement to ignore');
+        System.assert(
+            loggerFactory.debugLogCapture.doesNotContainInAnyMessage('trace statement to ignore'),
+            'falsely contained debug statement to ignore'
+        );
 
-  @isTest
-  public static void testSetGeneralLogLevel() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+        logger.setSystemDebugLevel(rflib_LogLevel.TRACE);
 
-    rflib_Logger logger = loggerFactory.createLogger('testSetGeneralLogLevel');
-
-    logger.trace('This statement should NOT be logged');
-    System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
-
-    logger.setGeneralLogLevel(rflib_LogLevel.WARN);
-    logger.setReportingLogLevel(rflib_LogLevel.ERROR);
-
-    logger.error('This statement should be logged');
-    System.assert(loggerFactory.eventCapture.eventHasBeenPublished());
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('This statement should be logged'));
-    System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('This statement should NOT be logged'));
-  }
-
-  @isTest
-  public static void testMessageWithArgs() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-
-    rflib_Logger logger = loggerFactory.createLogger('testMessageWithArgs');
-
-    logger.warn('warn message including {0}', new String[] { 'foo'});
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('warn message including foo'), 'debugLogger did not contain statement');
-  }
-
-  @isTest
-  public static void testMessageWithEmptyArgs() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-
-    rflib_Logger logger = loggerFactory.createLogger('testMessageWithEmptyArgs');
-
-    logger.warn('warn message including not including anything - {0}', new String[] {});
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('warn message including not including anything - {0}'), 'debugLogger did not contain statement');
-  }
-
-  @isTest
-  public static void testMessageWithException() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-
-    rflib_Logger logger = loggerFactory.createLogger('testMessageWithException');
-
-    Test.startTest();
-    try {
-      String.format(null, null);
-    } catch (Exception ex) {
-      logger.error('Caught an error', ex);
-    } 
-    Test.stopTest();
-    
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('Argument cannot be null'), 'debugLogger did not contain exception message');
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('rflib_DefaultLoggerTest'), 'debugLogger did not contain rflib_DefaultLoggerTest in stacktrace');
-  }
-
-  @isTest
-  public static void testCreateFromCustomSettings() {
-    insert new rflib_Logger_Settings__c(
-      Log_Size__c = 50,
-      System_Debug_Log_Level__c = 'WARN',
-      Log_Event_Reporting_Level__c = 'ERROR',
-      General_Log_Level__c = 'INFO',
-      Org_Wide_Email_Sender_Address__c = 'foo@email.com',
-      Batched_Log_Event_Reporting_Level__c = 'NONE'
-    );
-
-    Test.startTest();
-    System.assert(rflib_DefaultLogger.createFromCustomSettings('logger') != null);
-  }
-
-  @isTest
-  public static void testCreate() {
-    Test.startTest();
-    System.assert(rflib_DefaultLogger.create('logger') != null);
-  }
-
-  @IsTest
-  private static void testSyncLogEventPublisher() {
-    rflib_Logger logger = new rflib_DefaultLogger(
-      new rflib_DefaultLogger.LogEventPublisher(), 
-      new rflib_DefaultLogger.SystemDebugLogger(), 
-      'testSyncLogEventPublisher'
-    );
-
-    logger.info('This is a test message');
-
-    Test.startTest();
-    System.assertEquals(0, Limits.getPublishImmediateDML());
-    logger.reportLogs();
-    System.assertEquals(1, Limits.getPublishImmediateDML());
-    Test.stopTest();
-  }
-
-  @IsTest
-  private static void testSyncLogEventPublisher_publishingLimitOrDefaults() {
-    rflib_Logger logger = new rflib_DefaultLogger(
-      new rflib_DefaultLogger.LogEventPublisher(), 
-      new rflib_DefaultLogger.SystemDebugLogger(), 
-      'testSyncLogEventPublisher'
-    );
-
-    logger.info('This is a test message');
-
-    Test.startTest();
-    System.assertEquals(0, Limits.getPublishImmediateDML());
-    logger.reportLogs();
-    System.assertEquals(1, Limits.getPublishImmediateDML());
-    
-    rflib_GlobalSettings.overridePublishingLimitOrDefault(1);
-
-    logger.reportLogs();
-    System.assertEquals(1, Limits.getPublishImmediateDML());
-    Test.stopTest();
-  }
-
-  @IsTest
-  private static void testSyncLogEventPublisher_governorLimitReached() {
-    rflib_Logger logger = new rflib_DefaultLogger(
-      new rflib_DefaultLogger.LogEventPublisher(), 
-      new rflib_DefaultLogger.SystemDebugLogger(), 
-      'testSyncLogEventPublisher'
-    );
-
-    logger.info('This is a test message');
-
-    rflib_GlobalSettings.overridePublishingLimitOrDefault(null);
-
-    Test.startTest();
-    System.assertEquals(0, Limits.getPublishImmediateDML());
-    Integer i, count = Limits.getLimitPublishImmediateDML() + 1;
-    for (i = 0; i < count; i++) {
-      logger.reportLogs();
+        logger.trace('trace statement to include');
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('trace statement to include'),
+            'debugLogger did not contain statement'
+        );
     }
 
-    System.assertEquals(Limits.getLimitPublishImmediateDML(), Limits.getPublishImmediateDML());
-    Test.stopTest();
-  }
+    @isTest
+    public static void testSetReportingLogLevel() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
 
-  @IsTest
-  private static void testBatchLogEventPublisher() {
-    rflib_Logger logger = new rflib_DefaultLogger(
-      new rflib_DefaultLogger.BatchLogEventPublisher(), 
-      new rflib_DefaultLogger.SystemDebugLogger(), 
-      'testBatchLogEventPublisher'
-    );
-    
-    Test.startTest();
-    logger.info('This is a test message');
-    logger.info('This is a test message');
-    logger.reportLogs();
-    System.assertEquals(0, Limits.getPublishImmediateDML());
-    
-    logger.publishBatchedLogEvents();
-    System.assertEquals(1, Limits.getPublishImmediateDML());
-    Test.stopTest();
-  }
+        rflib_Logger logger = loggerFactory.createLogger('testSetReportingLogLevel');
 
-  @IsTest
-  private static void testSetBatchReportingLogLevel() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+        logger.info('This statement should NOT trigger the publishing of an event');
+        System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
 
-    rflib_Logger logger = loggerFactory.createLogger('testSetBatchReportingLogLevel');
+        logger.setReportingLogLevel(rflib_LogLevel.INFO);
 
-    logger.setReportingLogLevel(rflib_LogLevel.INFO);
-    logger.setBatchReportingLogLevel(rflib_LogLevel.INFO);
-   
-    Test.startTest();
-    logger.info('This is a test message');
-    logger.info('This is a test message');
-    System.assertEquals(0, Limits.getPublishImmediateDML());
-    
-    logger.publishBatchedLogEvents();
-    System.assertEquals(1, Limits.getPublishImmediateDML());
-    Test.stopTest();
-  }
-
-  @IsTest
-  private static void testFlushLogCacheLevel() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-
-    rflib_Logger logger = loggerFactory.createLogger('testFlushLogCacheLevel');
-
-    logger.setReportingLogLevel(rflib_LogLevel.INFO);
-    logger.setFlushLogCacheLevel(rflib_LogLevel.INFO);
-
-    Test.startTest();
-    System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
-    
-    logger.info('message1');
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('message1'));
-    
-    logger.info('message2');
-    System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('message1'));
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('message2'));
-    Test.stopTest();
-  }
-
-  @IsTest
-  private static void testLogMasking() {
-    List<rflib_Masking_Rule__mdt> rules = new List<rflib_Masking_Rule__mdt> {
-      createRule('secret', '****'),
-      createRule('[\\d\\d\\d-\\d\\d\\d-\\d\\d\\d]', '####')
-    };
-    rflib_StringUtil.allActiveMaskingRules = rules;
-
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-
-    rflib_Logger logger = loggerFactory.createLogger('testLogMasking');
-
-    logger.setReportingLogLevel(rflib_LogLevel.ERROR);
-    logger.setLogMaskingState(true);
-
-    Test.startTest();
-    System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
-    
-    logger.info('This message contains a secret word');
-    logger.info('The SSN is 123-456-789');
-    logger.error('And then an error occurred');
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('message contains'));
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('word'));
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('****'));
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('####'));
-    System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('secret'));
-    System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('123-456-789'));
-    
-    Test.stopTest();
-  }
-
-  @IsTest
-  private static void testTruncatedContext() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-    
-    Test.startTest();
-
-    String context = '40+ Character Context > 012345678901234567890';
-    rflib_Logger logger = loggerFactory.createLogger(context);
-
-    logger.fatal('fatal log statement');
-    Test.stopTest();
-
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage('fatal log statement'), 'event did not contain statement');
-
-    System.assertEquals(context.substring(0, 40), loggerFactory.eventCapture.getEvent().Context__c);
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage(context), 'event did not contain truncated context');
-    System.assert(loggerFactory.eventCapture.containsInAnyMessage(context), 'event did not contain truncated context');
-  }
-
-  @IsTest
-  private static void testApexPlatformInfo() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-    
-    Test.startTest();
-
-    User u = [SELECT Id FROM User LIMIT 1];
-    rflib_Logger logger = loggerFactory.createLogger('testApexPlatformInfo');
-
-    logger.fatal('fatal log statement');
-    Test.stopTest();
-
-    System.assert(loggerFactory.eventCapture.containsInPlatformInfo('"SOQL queries":1'), 'Platform info missed information:' + loggerFactory.eventCapture.getEvent().Platform_Info__c);
-    System.assert(loggerFactory.eventCapture.containsInPlatformInfo('"Query Rows":1'), 'Platform info missed information:' + loggerFactory.eventCapture.getEvent().Platform_Info__c);
-  }
-  
-  @IsTest
-  private static void testSetPlatformInfo() {
-    String platformInfo = '{"key": "some random platform info 123"}';
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-    
-    Test.startTest();
-
-    User u = [SELECT Id FROM User LIMIT 1];
-    rflib_Logger logger = loggerFactory.createLogger('testOverridePlatformInfo');
-
-    logger.setPlatformInfo(platformInfo);
-    logger.fatal('fatal log statement');
-    Test.stopTest();
-    
-    System.assertEquals(platformInfo, loggerFactory.eventCapture.getEvent().Platform_Info__c);
-    
-    System.assert(loggerFactory.eventCapture.doesNotContainInPlatformInfo('"SOQL queries":1'), 'Platform should not contain information:' + loggerFactory.eventCapture.getEvent().Platform_Info__c);
-    System.assert(loggerFactory.eventCapture.doesNotContainInPlatformInfo('"Query Rows":1'), 'Platform should not contain information:' + loggerFactory.eventCapture.getEvent().Platform_Info__c);
-  }
-
-  @IsTest
-  private static void testPrintLogs() {
-    rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
-
-    rflib_Logger logger = loggerFactory.createLogger('testPrintLogs');
-
-    Test.startTest();
-    createLogStatements(loggerFactory, logger);
-
-    String actualLogMessages = logger.printLogs();
-
-    Test.stopTest();
-
-    Assert.isTrue(actualLogMessages.contains('Log statements reported by'), 'debugLogger did not contain header statement'); 
-    Assert.isFalse(actualLogMessages.contains('first info statement'), 'debugLogger falsely contained statement');
-    Assert.isTrue(actualLogMessages.contains('warn statement'), 'debugLogger did not contain statement');
-  }
-
-  private static void createLogStatements(rflib_MockLoggerFactory loggerFactory, rflib_Logger logger) {
-    logger.trace('trace statement to ignore');
-    logger.info('first info statement');
-
-    Integer i;
-    for (i = 2; i < 101; i++) {
-      logger.info('info statement ' + i);
+        logger.info('This statement should trigger the publishing of an event');
+        System.assert(loggerFactory.eventCapture.eventHasBeenPublished());
     }
 
-    logger.warn('warn statement');
+    @isTest
+    public static void testSetReportingLogLevel_LevelCannotBeSetBelowInfo() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
 
-    System.assert(loggerFactory.eventCapture.eventHasBeenPublished(), 'event should have been published');
+        rflib_Logger logger = loggerFactory.createLogger('testSetReportingLogLevel_LevelCannotBeSetBelowInfo');
 
-    System.assert(loggerFactory.debugLogCapture.doesNotContainInAnyMessage('trace statement to ignore'), 'falsely contained trace statement to ignore');
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('first info statement'), 'debugLogger did not contain statement');
-    System.assert(loggerFactory.debugLogCapture.containsInAnyMessage('warn statement'), 'debugLogger did not contain statement');
+        // This will set the actual log level to INFO
+        logger.setReportingLogLevel(rflib_LogLevel.DEBUG);
 
-    loggerFactory.debugLogCapture.clearCapturedLogs();
-  }
+        logger.debug('This statement should NOT trigger the publishing of an event');
+        System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
 
-  private static rflib_Masking_Rule__mdt createRule(String target, String replacement) {
-    return new rflib_Masking_Rule__mdt(
-        Target__c = target,
-        Target_Type__c = 'RegEx',
-        Replacement__c = replacement,
-        Is_Active__c = true,
-        Order__c = 1
-    );
-  }
+        logger.info('This statement should trigger the publishing of an event');
+        System.assert(loggerFactory.eventCapture.eventHasBeenPublished());
+    }
+
+    @isTest
+    public static void testExceedMaxMessageSize() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testSetReportingLogLevel');
+
+        logger.setReportingLogLevel(rflib_LogLevel.ERROR);
+
+        String longMessage = 'a';
+        for (Integer i = 1; i < rflib_DefaultLogger.MAX_MESSAGE_SIZE; i++) {
+            longMessage += 'b';
+        }
+
+        longMessage += 'c';
+
+        logger.error(longMessage);
+
+        System.assert(loggerFactory.eventCapture.eventHasBeenPublished());
+        System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('a'));
+        System.assert(loggerFactory.eventCapture.containsInAnyMessage('c'));
+    }
+
+    @isTest
+    public static void testSetGeneralLogLevel() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testSetGeneralLogLevel');
+
+        logger.trace('This statement should NOT be logged');
+        System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
+
+        logger.setGeneralLogLevel(rflib_LogLevel.WARN);
+        logger.setReportingLogLevel(rflib_LogLevel.ERROR);
+
+        logger.error('This statement should be logged');
+        System.assert(loggerFactory.eventCapture.eventHasBeenPublished());
+        System.assert(loggerFactory.eventCapture.containsInAnyMessage('This statement should be logged'));
+        System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('This statement should NOT be logged'));
+    }
+
+    @isTest
+    public static void testMessageWithArgs() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testMessageWithArgs');
+
+        logger.warn('warn message including {0}', new List<String>{ 'foo' });
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('warn message including foo'),
+            'debugLogger did not contain statement'
+        );
+    }
+
+    @isTest
+    public static void testMessageWithEmptyArgs() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testMessageWithEmptyArgs');
+
+        logger.warn('warn message including not including anything - {0}', new List<String>{});
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('warn message including not including anything - {0}'),
+            'debugLogger did not contain statement'
+        );
+    }
+
+    @isTest
+    public static void testMessageWithException() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testMessageWithException');
+
+        Test.startTest();
+        try {
+            String.format(null, null);
+        } catch (Exception ex) {
+            logger.error('Caught an error', ex);
+        }
+        Test.stopTest();
+
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('Argument cannot be null'),
+            'debugLogger did not contain exception message'
+        );
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('rflib_DefaultLoggerTest'),
+            'debugLogger did not contain rflib_DefaultLoggerTest in stacktrace'
+        );
+    }
+
+    @isTest
+    public static void testCreateFromCustomSettings() {
+        insert new rflib_Logger_Settings__c(
+            Log_Size__c = 50,
+            System_Debug_Log_Level__c = 'WARN',
+            Log_Event_Reporting_Level__c = 'ERROR',
+            General_Log_Level__c = 'INFO',
+            Org_Wide_Email_Sender_Address__c = 'foo@email.com',
+            Batched_Log_Event_Reporting_Level__c = 'NONE'
+        );
+
+        Test.startTest();
+        System.assert(rflib_DefaultLogger.createFromCustomSettings('logger') != null);
+    }
+
+    @isTest
+    public static void testCreate() {
+        Test.startTest();
+        System.assert(rflib_DefaultLogger.create('logger') != null);
+    }
+
+    @IsTest
+    private static void testSyncLogEventPublisher() {
+        rflib_Logger logger = new rflib_DefaultLogger(
+            new rflib_DefaultLogger.LogEventPublisher(),
+            new rflib_DefaultLogger.SystemDebugLogger(),
+            'testSyncLogEventPublisher'
+        );
+
+        logger.info('This is a test message');
+
+        Test.startTest();
+        System.assertEquals(0, Limits.getPublishImmediateDML());
+        logger.reportLogs();
+        System.assertEquals(1, Limits.getPublishImmediateDML());
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void testSyncLogEventPublisher_publishingLimitOrDefaults() {
+        rflib_Logger logger = new rflib_DefaultLogger(
+            new rflib_DefaultLogger.LogEventPublisher(),
+            new rflib_DefaultLogger.SystemDebugLogger(),
+            'testSyncLogEventPublisher'
+        );
+
+        logger.info('This is a test message');
+
+        Test.startTest();
+        System.assertEquals(0, Limits.getPublishImmediateDML());
+        logger.reportLogs();
+        System.assertEquals(1, Limits.getPublishImmediateDML());
+
+        rflib_GlobalSettings.overridePublishingLimitOrDefault(1);
+
+        logger.reportLogs();
+        System.assertEquals(1, Limits.getPublishImmediateDML());
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void testSyncLogEventPublisher_governorLimitReached() {
+        rflib_Logger logger = new rflib_DefaultLogger(
+            new rflib_DefaultLogger.LogEventPublisher(),
+            new rflib_DefaultLogger.SystemDebugLogger(),
+            'testSyncLogEventPublisher'
+        );
+
+        logger.info('This is a test message');
+
+        rflib_GlobalSettings.overridePublishingLimitOrDefault(null);
+
+        Test.startTest();
+        System.assertEquals(0, Limits.getPublishImmediateDML());
+        Integer i, count = Limits.getLimitPublishImmediateDML() + 1;
+        for (i = 0; i < count; i++) {
+            logger.reportLogs();
+        }
+
+        System.assertEquals(Limits.getLimitPublishImmediateDML(), Limits.getPublishImmediateDML());
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void testBatchLogEventPublisher() {
+        rflib_Logger logger = new rflib_DefaultLogger(
+            new rflib_DefaultLogger.BatchLogEventPublisher(),
+            new rflib_DefaultLogger.SystemDebugLogger(),
+            'testBatchLogEventPublisher'
+        );
+
+        Test.startTest();
+        logger.info('This is a test message');
+        logger.info('This is a test message');
+        logger.reportLogs();
+        System.assertEquals(0, Limits.getPublishImmediateDML());
+
+        logger.publishBatchedLogEvents();
+        System.assertEquals(1, Limits.getPublishImmediateDML());
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void testSetBatchReportingLogLevel() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testSetBatchReportingLogLevel');
+
+        logger.setReportingLogLevel(rflib_LogLevel.INFO);
+        logger.setBatchReportingLogLevel(rflib_LogLevel.INFO);
+
+        Test.startTest();
+        logger.info('This is a test message');
+        logger.info('This is a test message');
+        System.assertEquals(0, Limits.getPublishImmediateDML());
+
+        logger.publishBatchedLogEvents();
+        System.assertEquals(1, Limits.getPublishImmediateDML());
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void testFlushLogCacheLevel() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testFlushLogCacheLevel');
+
+        logger.setReportingLogLevel(rflib_LogLevel.INFO);
+        logger.setFlushLogCacheLevel(rflib_LogLevel.INFO);
+
+        Test.startTest();
+        System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
+
+        logger.info('message1');
+        System.assert(loggerFactory.eventCapture.containsInAnyMessage('message1'));
+
+        logger.info('message2');
+        System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('message1'));
+        System.assert(loggerFactory.eventCapture.containsInAnyMessage('message2'));
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void testLogMasking() {
+        List<rflib_Masking_Rule__mdt> rules = new List<rflib_Masking_Rule__mdt>{
+            createRule('secret', '****'),
+            createRule('[\\d\\d\\d-\\d\\d\\d-\\d\\d\\d]', '####')
+        };
+        rflib_StringUtil.allActiveMaskingRules = rules;
+
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testLogMasking');
+
+        logger.setReportingLogLevel(rflib_LogLevel.ERROR);
+        logger.setLogMaskingState(true);
+
+        Test.startTest();
+        System.assert(loggerFactory.eventCapture.eventHasNotBeenPublished());
+
+        logger.info('This message contains a secret word');
+        logger.info('The SSN is 123-456-789');
+        logger.error('And then an error occurred');
+        System.assert(loggerFactory.eventCapture.containsInAnyMessage('message contains'));
+        System.assert(loggerFactory.eventCapture.containsInAnyMessage('word'));
+        System.assert(loggerFactory.eventCapture.containsInAnyMessage('****'));
+        System.assert(loggerFactory.eventCapture.containsInAnyMessage('####'));
+        System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('secret'));
+        System.assert(loggerFactory.eventCapture.doesNotContainInAnyMessage('123-456-789'));
+
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void testTruncatedContext() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        Test.startTest();
+
+        String context = '40+ Character Context > 012345678901234567890';
+        rflib_Logger logger = loggerFactory.createLogger(context);
+
+        logger.fatal('fatal log statement');
+        Test.stopTest();
+
+        System.assert(
+            loggerFactory.eventCapture.containsInAnyMessage('fatal log statement'),
+            'event did not contain statement'
+        );
+
+        System.assertEquals(context.substring(0, 40), loggerFactory.eventCapture.getEvent().Context__c);
+        System.assert(
+            loggerFactory.eventCapture.containsInAnyMessage(context),
+            'event did not contain truncated context'
+        );
+        System.assert(
+            loggerFactory.eventCapture.containsInAnyMessage(context),
+            'event did not contain truncated context'
+        );
+    }
+
+    @IsTest
+    private static void testApexPlatformInfo() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        Test.startTest();
+
+        User u = [SELECT Id FROM User LIMIT 1];
+        rflib_Logger logger = loggerFactory.createLogger('testApexPlatformInfo');
+
+        logger.fatal('fatal log statement');
+        Test.stopTest();
+
+        System.assert(
+            loggerFactory.eventCapture.containsInPlatformInfo('"SOQL queries":1'),
+            'Platform info missed information:' + loggerFactory.eventCapture.getEvent().Platform_Info__c
+        );
+        System.assert(
+            loggerFactory.eventCapture.containsInPlatformInfo('"Query Rows":1'),
+            'Platform info missed information:' + loggerFactory.eventCapture.getEvent().Platform_Info__c
+        );
+    }
+
+    @IsTest
+    private static void testSetPlatformInfo() {
+        String platformInfo = '{"key": "some random platform info 123"}';
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        Test.startTest();
+
+        User u = [SELECT Id FROM User LIMIT 1];
+        rflib_Logger logger = loggerFactory.createLogger('testOverridePlatformInfo');
+
+        logger.setPlatformInfo(platformInfo);
+        logger.fatal('fatal log statement');
+        Test.stopTest();
+
+        System.assertEquals(platformInfo, loggerFactory.eventCapture.getEvent().Platform_Info__c);
+
+        System.assert(
+            loggerFactory.eventCapture.doesNotContainInPlatformInfo('"SOQL queries":1'),
+            'Platform should not contain information:' + loggerFactory.eventCapture.getEvent().Platform_Info__c
+        );
+        System.assert(
+            loggerFactory.eventCapture.doesNotContainInPlatformInfo('"Query Rows":1'),
+            'Platform should not contain information:' + loggerFactory.eventCapture.getEvent().Platform_Info__c
+        );
+    }
+
+    @IsTest
+    private static void testPrintLogs() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testPrintLogs');
+
+        Test.startTest();
+        createLogStatements(loggerFactory, logger);
+
+        String actualLogMessages = logger.printLogs();
+
+        Test.stopTest();
+
+        Assert.isTrue(
+            actualLogMessages.contains('Log statements reported by'),
+            'debugLogger did not contain header statement'
+        );
+        Assert.isFalse(actualLogMessages.contains('first info statement'), 'debugLogger falsely contained statement');
+        Assert.isTrue(actualLogMessages.contains('warn statement'), 'debugLogger did not contain statement');
+    }
+
+    @isTest
+    static void testObservabilityLogEventCreation_LevelMatched() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testObservabilityLogEventCreation');
+
+        logger.setObservabilityLogLevel(rflib_LogLevel.WARN);
+
+        Assert.isFalse(
+            loggerFactory.eventCapture.hasAppEventBeenPublished(),
+            'One observability log event should be published.'
+        );
+
+        Test.startTest();
+        logger.warn('Test observability warning log');
+        Test.stopTest();
+
+        Assert.isTrue(
+            loggerFactory.eventCapture.hasAppEventBeenPublished(),
+            'One observability log event should be published.'
+        );
+
+        rflib_Application_Event_Occurred_Event__e event = loggerFactory.eventCapture.getAppEvent();
+        Assert.areEqual(
+            'rflib-warn-testObservabilityLogEventCreation',
+            event.Event_Name__c,
+            'Event name should be correctly formatted.'
+        );
+        Assert.isTrue(
+            event.Additional_Details__c.contains('Test observability warning log'),
+            'Log message should match.'
+        );
+    }
+
+    @isTest
+    static void testObservability_LogEventCreationWhenLevelMatches() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testObservabilityLogEventCreation');
+
+        logger.setObservabilityLogLevel(rflib_LogLevel.WARN);
+
+        Assert.isFalse(
+            loggerFactory.eventCapture.hasAppEventBeenPublished(),
+            'One observability log event should be published.'
+        );
+
+        Test.startTest();
+        logger.warn('Test observability warning log');
+        Test.stopTest();
+
+        Assert.isTrue(
+            loggerFactory.eventCapture.hasAppEventBeenPublished(),
+            'One observability log event should be published.'
+        );
+
+        rflib_Application_Event_Occurred_Event__e event = loggerFactory.eventCapture.getAppEvent();
+        Assert.areEqual(
+            'rflib-warn-testObservabilityLogEventCreation',
+            event.Event_Name__c,
+            'Event name should be correctly formatted.'
+        );
+        Assert.isTrue(
+            event.Additional_Details__c.contains('Test observability warning log'),
+            'Log message should match.'
+        );
+    }
+
+    @isTest
+    static void testObservability_NoLogEventCreationWhenLevelIsBelowThreshold() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testObservabilityNoLogEventCreation');
+
+        logger.setObservabilityLogLevel(rflib_LogLevel.ERROR);
+
+        Test.startTest();
+        logger.warn('This warning should not trigger an observability event');
+        Test.stopTest();
+
+        Assert.isFalse(
+            loggerFactory.eventCapture.hasAppEventBeenPublished(),
+            'No observability log event should be published when level is below threshold.'
+        );
+    }
+
+    @isTest
+    static void testObservabilityLogEventCreation_SettingInvalidLevelDefaultsToWarn() {
+        rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
+
+        rflib_Logger logger = loggerFactory.createLogger('testObservabilityInvalidLevelDefault');
+
+        logger.setObservabilityLogLevel(rflib_LogLevel.INFO);
+
+        Test.startTest();
+        logger.warn('This should trigger an event because default level is WARN');
+        Test.stopTest();
+
+        Assert.isTrue(
+            loggerFactory.eventCapture.hasAppEventBeenPublished(),
+            'An event should be published because invalid level defaults to WARN.'
+        );
+    }
+
+    @isTest
+    static void testObservabilityLogEventCreation_AppEventContributesTowardsPublishingLimit() {
+        rflib_DefaultLogger.LogEventPublisher eventPublisher = new rflib_DefaultLogger.LogEventPublisher();
+
+        rflib_Logger logger = new rflib_DefaultLogger(
+            eventPublisher,
+            new rflib_DefaultLogger.SystemDebugLogger(),
+            'testObservabilityLogEventCreation'
+        );
+
+        logger.setObservabilityLogLevel(rflib_LogLevel.WARN);
+
+        rflib_GlobalSettings.overridePublishingLimitOrDefault(2);
+
+        Test.startTest();
+        Assert.areEqual(0, eventPublisher.getPublishingCounter());
+        logger.warn('With observability enabled, an observed log message will require to Immediate DML');
+        Assert.areEqual(2, eventPublisher.getPublishingCounter());
+        Test.stopTest();
+    }
+
+    @isTest
+    static void testObservabilityLogEventCreation_AppEventNotPublishedWhenHittingPublishingLimit() {
+        rflib_DefaultLogger.LogEventPublisher eventPublisher = new rflib_DefaultLogger.LogEventPublisher();
+
+        rflib_Logger logger = new rflib_DefaultLogger(
+            eventPublisher,
+            new rflib_DefaultLogger.SystemDebugLogger(),
+            'testObservabilityLogEventCreation'
+        );
+
+        logger.setObservabilityLogLevel(rflib_LogLevel.WARN);
+
+        rflib_GlobalSettings.overridePublishingLimitOrDefault(1);
+
+        Test.startTest();
+        Assert.areEqual(0, eventPublisher.getPublishingCounter());
+        logger.warn('If the publishing limit is reached, an App Event will not be published');
+        Assert.areEqual(1, eventPublisher.getPublishingCounter());
+        Test.stopTest();
+    }
+
+    private static void createLogStatements(rflib_MockLoggerFactory loggerFactory, rflib_Logger logger) {
+        logger.trace('trace statement to ignore');
+        logger.info('first info statement');
+
+        Integer i;
+        for (i = 2; i < 101; i++) {
+            logger.info('info statement ' + i);
+        }
+
+        logger.warn('warn statement');
+
+        System.assert(loggerFactory.eventCapture.eventHasBeenPublished(), 'event should have been published');
+
+        System.assert(
+            loggerFactory.debugLogCapture.doesNotContainInAnyMessage('trace statement to ignore'),
+            'falsely contained trace statement to ignore'
+        );
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('first info statement'),
+            'debugLogger did not contain statement'
+        );
+        System.assert(
+            loggerFactory.debugLogCapture.containsInAnyMessage('warn statement'),
+            'debugLogger did not contain statement'
+        );
+
+        loggerFactory.debugLogCapture.clearCapturedLogs();
+    }
+
+    private static rflib_Masking_Rule__mdt createRule(String target, String replacement) {
+        return new rflib_Masking_Rule__mdt(
+            Target__c = target,
+            Target_Type__c = 'RegEx',
+            Replacement__c = replacement,
+            Is_Active__c = true,
+            Order__c = 1
+        );
+    }
 }

--- a/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
+++ b/rflib/test/default/classes/rflib_DefaultLoggerTest.cls
@@ -536,98 +536,98 @@ public class rflib_DefaultLoggerTest {
     }
 
     @isTest
-    static void testObservabilityLogEventCreation_LevelMatched() {
+    static void testLogAggregationLogEventCreation_LevelMatched() {
         rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
 
-        rflib_Logger logger = loggerFactory.createLogger('testObservabilityLogEventCreation');
+        rflib_Logger logger = loggerFactory.createLogger('testLogAggregationLogEventCreation');
 
-        logger.setObservabilityLogLevel(rflib_LogLevel.WARN);
+        logger.setLogAggregationLogLevel(rflib_LogLevel.WARN);
 
         Assert.isFalse(
             loggerFactory.eventCapture.hasAppEventBeenPublished(),
-            'One observability log event should be published.'
+            'One LogAggregation log event should be published.'
         );
 
         Test.startTest();
-        logger.warn('Test observability warning log');
+        logger.warn('Test LogAggregation warning log');
         Test.stopTest();
 
         Assert.isTrue(
             loggerFactory.eventCapture.hasAppEventBeenPublished(),
-            'One observability log event should be published.'
+            'One LogAggregation log event should be published.'
         );
 
         rflib_Application_Event_Occurred_Event__e event = loggerFactory.eventCapture.getAppEvent();
         Assert.areEqual(
-            'rflib-warn-testObservabilityLogEventCreation',
+            'rflib-warn-testLogAggregationLogEventCreation',
             event.Event_Name__c,
             'Event name should be correctly formatted.'
         );
         Assert.isTrue(
-            event.Additional_Details__c.contains('Test observability warning log'),
+            event.Additional_Details__c.contains('Test LogAggregation warning log'),
             'Log message should match.'
         );
     }
 
     @isTest
-    static void testObservability_LogEventCreationWhenLevelMatches() {
+    static void testLogAggregation_LogEventCreationWhenLevelMatches() {
         rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
 
-        rflib_Logger logger = loggerFactory.createLogger('testObservabilityLogEventCreation');
+        rflib_Logger logger = loggerFactory.createLogger('testLogAggregationLogEventCreation');
 
-        logger.setObservabilityLogLevel(rflib_LogLevel.WARN);
+        logger.setLogAggregationLogLevel(rflib_LogLevel.WARN);
 
         Assert.isFalse(
             loggerFactory.eventCapture.hasAppEventBeenPublished(),
-            'One observability log event should be published.'
+            'One LogAggregation log event should be published.'
         );
 
         Test.startTest();
-        logger.warn('Test observability warning log');
+        logger.warn('Test LogAggregation warning log');
         Test.stopTest();
 
         Assert.isTrue(
             loggerFactory.eventCapture.hasAppEventBeenPublished(),
-            'One observability log event should be published.'
+            'One LogAggregation log event should be published.'
         );
 
         rflib_Application_Event_Occurred_Event__e event = loggerFactory.eventCapture.getAppEvent();
         Assert.areEqual(
-            'rflib-warn-testObservabilityLogEventCreation',
+            'rflib-warn-testLogAggregationLogEventCreation',
             event.Event_Name__c,
             'Event name should be correctly formatted.'
         );
         Assert.isTrue(
-            event.Additional_Details__c.contains('Test observability warning log'),
+            event.Additional_Details__c.contains('Test LogAggregation warning log'),
             'Log message should match.'
         );
     }
 
     @isTest
-    static void testObservability_NoLogEventCreationWhenLevelIsBelowThreshold() {
+    static void testLogAggregation_NoLogEventCreationWhenLevelIsBelowThreshold() {
         rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
 
-        rflib_Logger logger = loggerFactory.createLogger('testObservabilityNoLogEventCreation');
+        rflib_Logger logger = loggerFactory.createLogger('testLogAggregationNoLogEventCreation');
 
-        logger.setObservabilityLogLevel(rflib_LogLevel.ERROR);
+        logger.setLogAggregationLogLevel(rflib_LogLevel.ERROR);
 
         Test.startTest();
-        logger.warn('This warning should not trigger an observability event');
+        logger.warn('This warning should not trigger an LogAggregation event');
         Test.stopTest();
 
         Assert.isFalse(
             loggerFactory.eventCapture.hasAppEventBeenPublished(),
-            'No observability log event should be published when level is below threshold.'
+            'No LogAggregation log event should be published when level is below threshold.'
         );
     }
 
     @isTest
-    static void testObservabilityLogEventCreation_SettingInvalidLevelDefaultsToWarn() {
+    static void testLogAggregationLogEventCreation_SettingInvalidLevelDefaultsToWarn() {
         rflib_MockLoggerFactory loggerFactory = new rflib_MockLoggerFactory();
 
-        rflib_Logger logger = loggerFactory.createLogger('testObservabilityInvalidLevelDefault');
+        rflib_Logger logger = loggerFactory.createLogger('testLogAggregationInvalidLevelDefault');
 
-        logger.setObservabilityLogLevel(rflib_LogLevel.INFO);
+        logger.setLogAggregationLogLevel(rflib_LogLevel.INFO);
 
         Test.startTest();
         logger.warn('This should trigger an event because default level is WARN');
@@ -640,37 +640,37 @@ public class rflib_DefaultLoggerTest {
     }
 
     @isTest
-    static void testObservabilityLogEventCreation_AppEventContributesTowardsPublishingLimit() {
+    static void testLogAggregationLogEventCreation_AppEventContributesTowardsPublishingLimit() {
         rflib_DefaultLogger.LogEventPublisher eventPublisher = new rflib_DefaultLogger.LogEventPublisher();
 
         rflib_Logger logger = new rflib_DefaultLogger(
             eventPublisher,
             new rflib_DefaultLogger.SystemDebugLogger(),
-            'testObservabilityLogEventCreation'
+            'testLogAggregationLogEventCreation'
         );
 
-        logger.setObservabilityLogLevel(rflib_LogLevel.WARN);
+        logger.setLogAggregationLogLevel(rflib_LogLevel.WARN);
 
         rflib_GlobalSettings.overridePublishingLimitOrDefault(2);
 
         Test.startTest();
         Assert.areEqual(0, eventPublisher.getPublishingCounter());
-        logger.warn('With observability enabled, an observed log message will require to Immediate DML');
+        logger.warn('With LogAggregation enabled, an observed log message will require to Immediate DML');
         Assert.areEqual(2, eventPublisher.getPublishingCounter());
         Test.stopTest();
     }
 
     @isTest
-    static void testObservabilityLogEventCreation_AppEventNotPublishedWhenHittingPublishingLimit() {
+    static void testLogAggregationLogEventCreation_AppEventNotPublishedWhenHittingPublishingLimit() {
         rflib_DefaultLogger.LogEventPublisher eventPublisher = new rflib_DefaultLogger.LogEventPublisher();
 
         rflib_Logger logger = new rflib_DefaultLogger(
             eventPublisher,
             new rflib_DefaultLogger.SystemDebugLogger(),
-            'testObservabilityLogEventCreation'
+            'testLogAggregationLogEventCreation'
         );
 
-        logger.setObservabilityLogLevel(rflib_LogLevel.WARN);
+        logger.setLogAggregationLogLevel(rflib_LogLevel.WARN);
 
         rflib_GlobalSettings.overridePublishingLimitOrDefault(1);
 

--- a/rflib/test/default/classes/rflib_MockLogger.cls
+++ b/rflib/test/default/classes/rflib_MockLogger.cls
@@ -37,7 +37,7 @@ public class rflib_MockLogger implements rflib_Logger {
     public rflib_LogLevel batchReportingLogLevel;
     public rflib_LogLevel systemDebugLevel;
     public rflib_LogLevel generalLogLevel;
-    public rflib_LogLevel observabilityLogLevel;
+    public rflib_LogLevel logAggregationLogLevel;
     public String platformInfo;
 
     public Boolean logsPrinted = false;
@@ -54,8 +54,8 @@ public class rflib_MockLogger implements rflib_Logger {
         this.reportingLogLevel = newLevel;
     }
 
-    public void setObservabilityLogLevel(rflib_LogLevel newLevel) {
-        this.observabilityLogLevel = newLevel;
+    public void setLogAggregationLogLevel(rflib_LogLevel newLevel) {
+        this.logAggregationLogLevel = newLevel;
     }
 
     public void setFlushLogCacheLevel(rflib_LogLevel newLevel) {

--- a/rflib/test/default/classes/rflib_MockLogger.cls
+++ b/rflib/test/default/classes/rflib_MockLogger.cls
@@ -37,6 +37,7 @@ public class rflib_MockLogger implements rflib_Logger {
     public rflib_LogLevel batchReportingLogLevel;
     public rflib_LogLevel systemDebugLevel;
     public rflib_LogLevel generalLogLevel;
+    public rflib_LogLevel observabilityLogLevel;
     public String platformInfo;
 
     public Boolean logsPrinted = false;
@@ -51,6 +52,10 @@ public class rflib_MockLogger implements rflib_Logger {
 
     public void setReportingLogLevel(rflib_LogLevel newLevel) {
         this.reportingLogLevel = newLevel;
+    }
+
+    public void setObservabilityLogLevel(rflib_LogLevel newLevel) {
+        this.observabilityLogLevel = newLevel;
     }
 
     public void setFlushLogCacheLevel(rflib_LogLevel newLevel) {

--- a/rflib/test/default/classes/rflib_MockLoggerFactory.cls
+++ b/rflib/test/default/classes/rflib_MockLoggerFactory.cls
@@ -29,26 +29,21 @@
 @isTest
 @SuppressWarnings('PMD.ClassNamingConventions')
 public class rflib_MockLoggerFactory implements rflib_LoggerFactory {
-
     public final DebugLogCapture debugLogCapture = new DebugLogCapture();
     public final EventCapture eventCapture = new EventCapture();
 
     private final rflib_LogLevel systemDebugLogLevel;
 
     public rflib_MockLoggerFactory() {
-       this(null);
+        this(null);
     }
 
     public rflib_MockLoggerFactory(rflib_LogLevel systemDebugLogLevel) {
-       this.systemDebugLogLevel = systemDebugLogLevel;
+        this.systemDebugLogLevel = systemDebugLogLevel;
     }
 
     public rflib_Logger createLogger(String context) {
-        rflib_DefaultLogger result = new rflib_DefaultLogger(
-            eventCapture,
-            debugLogCapture,
-            context
-        );
+        rflib_DefaultLogger result = new rflib_DefaultLogger(eventCapture, debugLogCapture, context);
 
         if (systemDebugLogLevel != null) {
             result.setSystemDebugLevel(rflib_LogLevel.DEBUG);
@@ -57,18 +52,13 @@ public class rflib_MockLoggerFactory implements rflib_LoggerFactory {
     }
 
     public rflib_Logger createBatchedLogger(String context) {
-        rflib_DefaultLogger result = new rflib_DefaultLogger(
-            eventCapture,
-            debugLogCapture,
-            context
-        );
+        rflib_DefaultLogger result = new rflib_DefaultLogger(eventCapture, debugLogCapture, context);
 
         if (systemDebugLogLevel != null) {
             result.setSystemDebugLevel(rflib_LogLevel.DEBUG);
         }
         return result;
     }
-
 
     public class DebugLogCapture implements rflib_DefaultLogger.DebugLogger {
         public final List<String> capturedLogMessages = new List<String>();
@@ -82,30 +72,32 @@ public class rflib_MockLoggerFactory implements rflib_LoggerFactory {
         }
 
         public Boolean doesNotContainInAnyMessage(String substring) {
-          for (String message : capturedLogMessages) {
-            if (message.contains(substring)) {
-              System.debug('Actual messages:\n' + String.join(capturedLogMessages, '\n'));
-              return false;
+            for (String message : capturedLogMessages) {
+                if (message.contains(substring)) {
+                    System.debug('Actual messages:\n' + String.join(capturedLogMessages, '\n'));
+                    return false;
+                }
             }
-          }
 
-          return true;
+            return true;
         }
 
         public Boolean containsInAnyMessage(String substring) {
-          for (String message : capturedLogMessages) {
-            if (message.contains(substring)) {
-              return true;
+            for (String message : capturedLogMessages) {
+                if (message.contains(substring)) {
+                    return true;
+                }
             }
-          }
 
-          System.debug('Actual messages:\n' + String.join(capturedLogMessages, '\n'));
-          return false;
+            System.debug('Actual messages:\n' + String.join(capturedLogMessages, '\n'));
+            return false;
         }
     }
 
     public class EventCapture implements rflib_EventPublisher {
-        private List<rflib_Log_Event__e> capturedEvents;
+        private List<rflib_Log_Event__e> capturedLogEvents;
+        private List<rflib_Application_Event_Occurred_Event__e> capturedAppEvents;
+
         private Integer publishingCount = 0;
 
         public Integer getPublishingCounter() {
@@ -113,61 +105,101 @@ public class rflib_MockLoggerFactory implements rflib_LoggerFactory {
         }
 
         public Database.SaveResult publish(SObject event) {
-          capturedEvents = new List<rflib_Log_Event__e> { (rflib_Log_Event__e) event };
-          return null;
+            Schema.SObjectType evtType = event.getSObjectType();
+
+            if (evtType == rflib_Log_Event__e.SObjectType) {
+                capturedLogEvents = new List<rflib_Log_Event__e>{ (rflib_Log_Event__e) event };
+            } else if (evtType == rflib_Application_Event_Occurred_Event__e.SObjectType) {
+                capturedAppEvents = new List<rflib_Application_Event_Occurred_Event__e>{
+                    (rflib_Application_Event_Occurred_Event__e) event
+                };
+            }
+
+            return null;
         }
 
         public List<Database.SaveResult> publish(List<SObject> events) {
-          capturedEvents = (List<rflib_Log_Event__e>) events;
-          return null;
+            List<rflib_Log_Event__e> logEventsToPublish = new List<rflib_Log_Event__e>();
+            List<rflib_Application_Event_Occurred_Event__e> appEventsToPublish = new List<rflib_Application_Event_Occurred_Event__e>();
+
+            for (SObject evt : events) {
+                Schema.SObjectType evtType = evt.getSObjectType();
+
+                if (evtType == rflib_Log_Event__e.SObjectType) {
+                    logEventsToPublish.add((rflib_Log_Event__e) evt);
+                } else if (evtType == rflib_Application_Event_Occurred_Event__e.SObjectType) {
+                    appEventsToPublish.add((rflib_Application_Event_Occurred_Event__e) evt);
+                }
+            }
+
+            capturedLogEvents = logEventsToPublish;
+            capturedAppEvents = appEventsToPublish;
+
+            return null;
         }
 
         public Boolean eventHasNotBeenPublished() {
-          return capturedEvents == null;
+            return capturedLogEvents == null || capturedLogEvents.isEmpty();
         }
 
         public Boolean eventHasBeenPublished() {
-          return capturedEvents != null;
+            return capturedLogEvents != null && !capturedLogEvents.isEmpty();
+        }
+
+        public Boolean hasAppEventNotBeenPublished() {
+            return capturedAppEvents == null || capturedAppEvents.isEmpty();
+        }
+
+        public Boolean hasAppEventBeenPublished() {
+            return capturedAppEvents != null && !capturedAppEvents.isEmpty();
         }
 
         public rflib_Log_Event__e getEvent() {
-          return getEvent(0);
+            return getEvent(0);
         }
 
         public rflib_Log_Event__e getEvent(Integer index) {
-          return capturedEvents[index];
+            return capturedLogEvents[index];
+        }
+
+        public rflib_Application_Event_Occurred_Event__e getAppEvent() {
+            return getAppEvent(0);
+        }
+
+        public rflib_Application_Event_Occurred_Event__e getAppEvent(Integer index) {
+            return capturedAppEvents[index];
         }
 
         public Boolean doesNotContainInAnyMessage(String substring) {
-          Boolean result = getEvent().Log_Messages__c.contains(substring);
-          if (result) {
-            System.debug('Actual event message:\n' + getEvent().Log_Messages__c);
-          }
-          return result == false;
+            Boolean result = getEvent().Log_Messages__c.contains(substring);
+            if (result) {
+                System.debug('Actual event message:\n' + getEvent().Log_Messages__c);
+            }
+            return result == false;
         }
 
         public Boolean containsInAnyMessage(String substring) {
-          Boolean result = getEvent().Log_Messages__c.contains(substring);
-          if (!result) {
-            System.debug('Actual event message:\n' + getEvent().Log_Messages__c);
-          }
-          return result;
+            Boolean result = getEvent().Log_Messages__c.contains(substring);
+            if (!result) {
+                System.debug('Actual event message:\n' + getEvent().Log_Messages__c);
+            }
+            return result;
         }
 
         public Boolean doesNotContainInPlatformInfo(String substring) {
-          Boolean result = getEvent().Platform_Info__c.contains(substring);
-          if (result) {
-            System.debug('Actual event message:\n' + getEvent().Platform_Info__c);
-          }
-          return result == false;
+            Boolean result = getEvent().Platform_Info__c.contains(substring);
+            if (result) {
+                System.debug('Actual event message:\n' + getEvent().Platform_Info__c);
+            }
+            return result == false;
         }
 
         public Boolean containsInPlatformInfo(String substring) {
-          Boolean result = getEvent().Platform_Info__c.contains(substring);
-          if (!result) {
-            System.debug('Actual event message:\n' + getEvent().Platform_Info__c);
-          }
-          return result;
+            Boolean result = getEvent().Platform_Info__c.contains(substring);
+            if (!result) {
+                System.debug('Actual event message:\n' + getEvent().Platform_Info__c);
+            }
+            return result;
         }
     }
 }

--- a/scripts/apex/ConfigureCustomSettings.apex
+++ b/scripts/apex/ConfigureCustomSettings.apex
@@ -2,5 +2,6 @@ rflib_Logger_Settings__c settings = rflib_Logger_Settings__c.getOrgDefaults();
 settings.Client_Console_Log_Level__c = 'DEBUG';
 settings.Log_Event_Reporting_Level__c = 'INFO';
 settings.Archive_Log_Level__c = 'INFO';
+settings.Observability_Log_Level__c = 'WARN';
 
 upsert settings;

--- a/scripts/apex/ConfigureCustomSettings.apex
+++ b/scripts/apex/ConfigureCustomSettings.apex
@@ -2,6 +2,6 @@ rflib_Logger_Settings__c settings = rflib_Logger_Settings__c.getOrgDefaults();
 settings.Client_Console_Log_Level__c = 'DEBUG';
 settings.Log_Event_Reporting_Level__c = 'INFO';
 settings.Archive_Log_Level__c = 'INFO';
-settings.Observability_Log_Level__c = 'WARN';
+settings.Log_Aggregation_Log_Level__c = 'WARN';
 
 upsert settings;


### PR DESCRIPTION
Added support for Log Aggregation functionality linking RFLIB logs and App Events together. With the log level set to anything other than NONE, RFLIB will create an Application Event for log events that meet the defined log level. These can then be reviewed in the Application Events Dashboard and used as an initial reference for taking action.