### PR TITLE
Add View All Fields Permission to Permissions Explorer

### DIFF
--- a/rflib-fs/main/default/classes/rflib_FeatureSwitch.cls-meta.xml
+++ b/rflib-fs/main/default/classes/rflib_FeatureSwitch.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-fs/main/default/classes/rflib_FeatureSwitchesController.cls-meta.xml
+++ b/rflib-fs/main/default/classes/rflib_FeatureSwitchesController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-fs/main/default/classes/rflib_GetFeatureSwitchValueAction.cls-meta.xml
+++ b/rflib-fs/main/default/classes/rflib_GetFeatureSwitchValueAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-fs/main/default/lwc/rflibFeatureSwitches/rflibFeatureSwitches.js-meta.xml
+++ b/rflib-fs/main/default/lwc/rflibFeatureSwitches/rflibFeatureSwitches.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rflib-fs/test/default/classes/rflib_FeatureSwitchTest.cls-meta.xml
+++ b/rflib-fs/test/default/classes/rflib_FeatureSwitchTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-fs/test/default/classes/rflib_FeatureSwitchesControllerTest.cls-meta.xml
+++ b/rflib-fs/test/default/classes/rflib_FeatureSwitchesControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-fs/test/default/classes/rflib_GetFeatureSwitchValueActionTest.cls-meta.xml
+++ b/rflib-fs/test/default/classes/rflib_GetFeatureSwitchValueActionTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-tf/main/default/classes/rflib_RetryableActionHandler.cls-meta.xml
+++ b/rflib-tf/main/default/classes/rflib_RetryableActionHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-tf/main/default/classes/rflib_RetryableActionManager.cls-meta.xml
+++ b/rflib-tf/main/default/classes/rflib_RetryableActionManager.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-tf/main/default/classes/rflib_TriggerHandler.cls-meta.xml
+++ b/rflib-tf/main/default/classes/rflib_TriggerHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-tf/main/default/classes/rflib_TriggerManager.cls-meta.xml
+++ b/rflib-tf/main/default/classes/rflib_TriggerManager.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-tf/main/default/triggers/rflib_RetryableActionTrigger.trigger-meta.xml
+++ b/rflib-tf/main/default/triggers/rflib_RetryableActionTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>62.0</apiVersion>
+  <apiVersion>63.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/rflib-tf/test/default/classes/rflib_MockRetryableActionHandler.cls-meta.xml
+++ b/rflib-tf/test/default/classes/rflib_MockRetryableActionHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-tf/test/default/classes/rflib_MockTriggerConfigQueryLocator.cls-meta.xml
+++ b/rflib-tf/test/default/classes/rflib_MockTriggerConfigQueryLocator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-tf/test/default/classes/rflib_MockTriggerHandler.cls-meta.xml
+++ b/rflib-tf/test/default/classes/rflib_MockTriggerHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-tf/test/default/classes/rflib_RetryableActionManagerTest.cls-meta.xml
+++ b/rflib-tf/test/default/classes/rflib_RetryableActionManagerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib-tf/test/default/classes/rflib_TriggerManagerTest.cls-meta.xml
+++ b/rflib-tf/test/default/classes/rflib_TriggerManagerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/aura/rflibLoggerCmp/rflibLoggerCmp.cmp-meta.xml
+++ b/rflib/main/default/aura/rflibLoggerCmp/rflibLoggerCmp.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/rflib/main/default/classes/rflib_AbstractArchiveCleanup.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_AbstractArchiveCleanup.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_ApexJobSchedulerController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_ApexJobSchedulerController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_ApplicationEventArchiveCleanup.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_ApplicationEventArchiveCleanup.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_ApplicationEventArchiver.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_ApplicationEventArchiver.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_ApplicationEventController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_ApplicationEventController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_ApplicationEventDetails.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_ApplicationEventDetails.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_ApplicationEventLogger.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_ApplicationEventLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_ApplicationEventLoggerAction.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_ApplicationEventLoggerAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_ApplicationEventService.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_ApplicationEventService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_ArchiveLogAction.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_ArchiveLogAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_BigObjectCounter.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_BigObjectCounter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_BigObjectDatabaseExecutor.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_BigObjectDatabaseExecutor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_BigObjectStatController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_BigObjectStatController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_CollectionUtil.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_CollectionUtil.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_ControllerUtil.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_ControllerUtil.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_CustomSettingsEditorController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_CustomSettingsEditorController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DatabaseCursorQueryResult.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DatabaseCursorQueryResult.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DatabaseDmlExecutor.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DatabaseDmlExecutor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DatabaseQueryExecutor.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DatabaseQueryExecutor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DefaultApplicationEventLogger.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DefaultApplicationEventLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DefaultApplicationEventService.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DefaultApplicationEventService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DefaultBigObjectDatabaseExecutor.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DefaultBigObjectDatabaseExecutor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DefaultLogFinalizer.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DefaultLogFinalizer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DefaultLogTimer.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DefaultLogTimer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DefaultLogger.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DefaultLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DefaultLoggerFactory.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DefaultLoggerFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_DmlExecutor.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_DmlExecutor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_EventBusPublisher.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_EventBusPublisher.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_EventPublisher.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_EventPublisher.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_GlobalSettings.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_GlobalSettings.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_HttpCalloutLogAction.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_HttpCalloutLogAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_HttpEndpointMocker.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_HttpEndpointMocker.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_HttpRequest.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_HttpRequest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_InvalidArgumentException.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_InvalidArgumentException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_InvalidStateException.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_InvalidStateException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_LogArchiveController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_LogArchiveController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_LogEventViewerController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_LogEventViewerController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_LogFinalizer.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_LogFinalizer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_LogLevel.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_LogLevel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_LogTimer.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_LogTimer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_Logger.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_Logger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_LoggerController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_LoggerController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_LoggerFactory.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_LoggerFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_LoggerFlowAction.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_LoggerFlowAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_LoggerUtil.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_LoggerUtil.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_OmniStudioRemoteActions.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_OmniStudioRemoteActions.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_OrgLimitsController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_OrgLimitsController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_OrgUtil.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_OrgUtil.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_PermissionsExplorerController.cls
+++ b/rflib/main/default/classes/rflib_PermissionsExplorerController.cls
@@ -522,6 +522,7 @@ public with sharing class rflib_PermissionsExplorerController {
         @AuraEnabled public Boolean PermissionsRead;
         @AuraEnabled public Boolean PermissionsCreate;
         @AuraEnabled public Boolean PermissionsDelete;
+        @AuraEnabled public Boolean PermissionsViewAllFields;
         @AuraEnabled public Boolean PermissionsViewAllRecords;
         @AuraEnabled public Boolean PermissionsModifyAllRecords;
 
@@ -564,6 +565,7 @@ public with sharing class rflib_PermissionsExplorerController {
             this.PermissionsRead = record.PermissionsRead;
             this.PermissionsCreate = record.PermissionsCreate;
             this.PermissionsDelete = record.PermissionsDelete;
+            this.PermissionsViewAllFields = record.PermissionsViewAllFields;
             this.PermissionsViewAllRecords = record.PermissionsViewAllRecords;
             this.PermissionsModifyAllRecords = record.PermissionsModifyAllRecords;
 

--- a/rflib/main/default/classes/rflib_PermissionsExplorerController.cls
+++ b/rflib/main/default/classes/rflib_PermissionsExplorerController.cls
@@ -40,7 +40,7 @@ public with sharing class rflib_PermissionsExplorerController {
     
     @TestVisible private static final String COUNT = 'SELECT COUNT()';
     @TestVisible private static final String FLS_FIELDS = 'SELECT Parent.Label, Parent.Profile.Name, Parent.IsOwnedByProfile, Parent.PermissionSetGroupId, SobjectType, Field, PermissionsEdit, PermissionsRead';
-    @TestVisible private static final String OBJ_FIELDS = 'SELECT Parent.Label, Parent.Profile.Name, Parent.IsOwnedByProfile, Parent.PermissionSetGroupId, SobjectType, PermissionsRead, PermissionsCreate, PermissionsEdit, PermissionsDelete, PermissionsViewAllRecords, PermissionsModifyAllRecords';
+    @TestVisible private static final String OBJ_FIELDS = 'SELECT Parent.Label, Parent.Profile.Name, Parent.IsOwnedByProfile, Parent.PermissionSetGroupId, SobjectType, PermissionsRead, PermissionsCreate, PermissionsEdit, PermissionsDelete, PermissionsViewAllFields, PermissionsViewAllRecords, PermissionsModifyAllRecords';
     @TestVisible private static final String APEX_FIELDS = 'SELECT Parent.Label, Parent.Profile.Name, Parent.IsOwnedByProfile, Parent.PermissionSetGroupId, SetupEntityType, SetupEntityId';
  
     @TestVisible private static final String FLS_TABLE = ' FROM FieldPermissions';

--- a/rflib/main/default/classes/rflib_PermissionsExplorerController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_PermissionsExplorerController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_PublicGroupMemberManagerController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_PublicGroupMemberManagerController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_QueryExecutor.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_QueryExecutor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_SOQL.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_SOQL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_SaveAppEventOccurrenceAction.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_SaveAppEventOccurrenceAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_SendLogEventEmailAction.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_SendLogEventEmailAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_StartLogTimerFlowAction.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_StartLogTimerFlowAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_StopLogTimerFlowAction.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_StopLogTimerFlowAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_StringUtil.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_StringUtil.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_TraceId.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_TraceId.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_UserPermAssignmentController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_UserPermAssignmentController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_UserPermSetManagerController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_UserPermSetManagerController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/classes/rflib_UserProfileResolverController.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_UserProfileResolverController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/main/default/flows/RFLIB_Application_Event_Occurred_Handler.flow-meta.xml
+++ b/rflib/main/default/flows/RFLIB_Application_Event_Occurred_Handler.flow-meta.xml
@@ -46,7 +46,7 @@
             </value>
         </inputParameters>
     </actionCalls>
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <description>Handles the occurrence of an Application Event Platform Event to store it in the Custom Object.</description>
     <environments>Default</environments>
     <interviewLabel>RFLIB Application Event {!$Flow.CurrentDateTime}</interviewLabel>

--- a/rflib/main/default/flows/rflib_Before_Insert_Application_Event_Handler.flow-meta.xml
+++ b/rflib/main/default/flows/rflib_Before_Insert_Application_Event_Handler.flow-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <assignments>
         <description>Sets the record name to a concatenated string of the event name and the date of occurrence.</description>
         <name>Assign_Record_Name</name>

--- a/rflib/main/default/flows/rflib_Log_Event_Handler.flow-meta.xml
+++ b/rflib/main/default/flows/rflib_Log_Event_Handler.flow-meta.xml
@@ -69,7 +69,7 @@ IMPORTANT: This element must be first in this flow due to callout errors as a re
         <nameSegment>rflib_SendLogEventEmailAction</nameSegment>
         <versionSegment>1</versionSegment>
     </actionCalls>
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <description>Flow to execute when an RFLIB Log Event has been dispatched. The handler currently invokes the Send Log Event Email action, but can be extended to, for example, persist log information in a Custom Object.</description>
     <environments>Default</environments>
     <interviewLabel>Log Event Handler {!$Flow.CurrentDateTime}: {!$Record.Context__c} - {!$Record.ReplayId} - {!$Record.CreatedById} - {!$Record.Log_Level__c}</interviewLabel>

--- a/rflib/main/default/lwc/rflibApexJobScheduler/rflibApexJobScheduler.js-meta.xml
+++ b/rflib/main/default/lwc/rflibApexJobScheduler/rflibApexJobScheduler.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>RFLIB Apex Job Scheduler</masterLabel>
     <description>Displays and manages the status of a scheduled Apex job.</description>

--- a/rflib/main/default/lwc/rflibApplicationEventLogger/rflibApplicationEventLogger.js-meta.xml
+++ b/rflib/main/default/lwc/rflibApplicationEventLogger/rflibApplicationEventLogger.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rflib/main/default/lwc/rflibConfirmationDialog/rflibConfirmationDialog.js-meta.xml
+++ b/rflib/main/default/lwc/rflibConfirmationDialog/rflibConfirmationDialog.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <description>Confirmation Dialog</description>
     <isExposed>false</isExposed>
     <masterLabel>Confirmation Dialog</masterLabel>

--- a/rflib/main/default/lwc/rflibCustomSettingsEditor/rflibCustomSettingsEditor.js-meta.xml
+++ b/rflib/main/default/lwc/rflibCustomSettingsEditor/rflibCustomSettingsEditor.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>RFLIB Logger Settings Editor</masterLabel>
     <targets>

--- a/rflib/main/default/lwc/rflibLogEventList/rflibLogEventList.js-meta.xml
+++ b/rflib/main/default/lwc/rflibLogEventList/rflibLogEventList.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rflib/main/default/lwc/rflibLogEventListRow/rflibLogEventListRow.js-meta.xml
+++ b/rflib/main/default/lwc/rflibLogEventListRow/rflibLogEventListRow.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rflib/main/default/lwc/rflibLogEventMonitor/rflibLogEventMonitor.js-meta.xml
+++ b/rflib/main/default/lwc/rflibLogEventMonitor/rflibLogEventMonitor.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Log Event Monitor</masterLabel>
     <targets>

--- a/rflib/main/default/lwc/rflibLogEventViewer/rflibLogEventViewer.js-meta.xml
+++ b/rflib/main/default/lwc/rflibLogEventViewer/rflibLogEventViewer.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rflib/main/default/lwc/rflibLogger/rflibLogger.js-meta.xml
+++ b/rflib/main/default/lwc/rflibLogger/rflibLogger.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="rflibLogger">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rflib/main/default/lwc/rflibOrgLimitStat/rflibOrgLimitStat.js-meta.xml
+++ b/rflib/main/default/lwc/rflibOrgLimitStat/rflibOrgLimitStat.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>RFLIB Org Limit Stat</masterLabel>
     <targets>

--- a/rflib/main/default/lwc/rflibPaginator/rflibPaginator.js-meta.xml
+++ b/rflib/main/default/lwc/rflibPaginator/rflibPaginator.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rflib/main/default/lwc/rflibPermissionsExplorer/rflibPermissionsExplorer.js
+++ b/rflib/main/default/lwc/rflibPermissionsExplorer/rflibPermissionsExplorer.js
@@ -142,7 +142,7 @@ const PERMISSION_TYPES = {
 };
 
 const OBJECT_PERMISSIONS_CSV_HEADER =
-    '"PROFILE/PERMISSION SET","OBJECT","READ ACCESS","CREATE ACCESS","EDIT ACCESS","DELETE ACCESS","VIEW ALL","MODIFY ALL"\r\n';
+    '"PROFILE/PERMISSION SET","OBJECT","READ ACCESS","CREATE ACCESS","EDIT ACCESS","DELETE ACCESS","VIEW ALL FIELDS","VIEW ALL RECORDS","MODIFY ALL RECORDS"\r\n';
 const FIELD_PERMISSIONS_CSV_HEADER = '"PROFILE/PERMISSION SET","OBJECT","FIELD","READ ACCESS","EDIT ACCESS"\r\n';
 
 const logger = createLogger('PermissionsExplorer');
@@ -492,6 +492,8 @@ export default class PermissionsExplorer extends LightningElement {
                     '","' +
                     permission.PermissionsDelete +
                     '","' +
+                    permission.PermissionsViewAllFields +
+                    '","' +
                     permission.PermissionsViewAllRecords +
                     '","' +
                     permission.PermissionsModifyAllRecords +
@@ -565,6 +567,9 @@ export default class PermissionsExplorer extends LightningElement {
                     consolidatedPermissions[consolidatePermissionKey].PermissionsEdit || permission.PermissionsEdit;
                 consolidatedPermissions[consolidatePermissionKey].PermissionsDelete =
                     consolidatedPermissions[consolidatePermissionKey].PermissionsDelete || permission.PermissionsDelete;
+                consolidatedPermissions[consolidatePermissionKey].PermissionsViewAllFields =
+                    consolidatedPermissions[consolidatePermissionKey].PermissionsViewAllFields ||
+                    permission.PermissionsViewAllFields;
                 consolidatedPermissions[consolidatePermissionKey].PermissionsViewAllRecords =
                     consolidatedPermissions[consolidatePermissionKey].PermissionsViewAllRecords ||
                     permission.PermissionsViewAllRecords;

--- a/rflib/main/default/lwc/rflibPermissionsExplorer/rflibPermissionsExplorer.js-meta.xml
+++ b/rflib/main/default/lwc/rflibPermissionsExplorer/rflibPermissionsExplorer.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Permissions Explorer</masterLabel>
     <targets>

--- a/rflib/main/default/lwc/rflibPermissionsTable/rflibPermissionsTable.html
+++ b/rflib/main/default/lwc/rflibPermissionsTable/rflibPermissionsTable.html
@@ -103,10 +103,13 @@
                                     <div class="slds-truncate" title="Delete Access">Delete Access</div>
                                 </th>
                                 <th scope="col">
-                                    <div class="slds-truncate" title="View All">View All</div>
+                                    <div class="slds-truncate" title="View All">View All Fields</div>
                                 </th>
                                 <th scope="col">
-                                    <div class="slds-truncate" title="Modify All">Modify All</div>
+                                    <div class="slds-truncate" title="View All">View All Records</div>
+                                </th>
+                                <th scope="col">
+                                    <div class="slds-truncate" title="Modify All">Modify All Records</div>
                                 </th>
                             </tr>
                         </thead>
@@ -130,6 +133,9 @@
                                     </td>
                                     <td class="slds-truncate">
                                         <div>{rec.PermissionsDelete}</div>
+                                    </td>
+                                    <td class="slds-truncate">
+                                        <div>{rec.PermissionsViewAllFields}</div>
                                     </td>
                                     <td class="slds-truncate">
                                         <div>{rec.PermissionsViewAllRecords}</div>

--- a/rflib/main/default/lwc/rflibPermissionsTable/rflibPermissionsTable.js-meta.xml
+++ b/rflib/main/default/lwc/rflibPermissionsTable/rflibPermissionsTable.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rflib/main/default/lwc/rflibPublicGroupMemberManager/rflibPublicGroupMemberManager.js-meta.xml
+++ b/rflib/main/default/lwc/rflibPublicGroupMemberManager/rflibPublicGroupMemberManager.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <masterLabel>RFLIB Public Group Member Manager</masterLabel>
     <isExposed>true</isExposed>
     <targets>

--- a/rflib/main/default/lwc/rflibUserPermissionAssignmentList/rflibUserPermissionAssignmentList.js-meta.xml
+++ b/rflib/main/default/lwc/rflibUserPermissionAssignmentList/rflibUserPermissionAssignmentList.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>RFLIB User Permission Assignments</masterLabel>
     <targets>

--- a/rflib/main/default/lwc/rflibUserPermissionSetManager/rflibUserPermissionSetManager.js-meta.xml
+++ b/rflib/main/default/lwc/rflibUserPermissionSetManager/rflibUserPermissionSetManager.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>RFLIB Permission Set Manager</masterLabel>
     <targets>

--- a/rflib/main/default/lwc/rflibUserProfileResolver/rflibUserProfileResolver.js-meta.xml
+++ b/rflib/main/default/lwc/rflibUserProfileResolver/rflibUserProfileResolver.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/rflib/main/default/permissionsets/rflib_Archive_Application_Events.permissionset-meta.xml
+++ b/rflib/main/default/permissionsets/rflib_Archive_Application_Events.permissionset-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>This permission set controls access to the Application Event archiving functionality in the RFLIB package.</description>
     <fieldPermissions>
         <editable>true</editable>
         <field>rflib_Application_Event_Archive__b.Additional_Details__c</field>

--- a/rflib/main/default/permissionsets/rflib_Create_Application_Event.permissionset-meta.xml
+++ b/rflib/main/default/permissionsets/rflib_Create_Application_Event.permissionset-meta.xml
@@ -4,6 +4,7 @@
         <apexClass>rflib_ApplicationEventController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
+    <description>This permission set grants users the minimum required permissions to create application events in the RFLIB framework.</description>
     <fieldPermissions>
         <editable>true</editable>
         <field>rflib_Application_Event__c.Additional_Details__c</field>

--- a/rflib/main/default/permissionsets/rflib_Ops_Center_Access.permissionset-meta.xml
+++ b/rflib/main/default/permissionsets/rflib_Ops_Center_Access.permissionset-meta.xml
@@ -69,6 +69,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>PushTopic</object>
+        <viewAllFields>false</viewAllFields>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <objectPermissions>
@@ -78,6 +79,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>StreamingChannel</object>
+        <viewAllFields>false</viewAllFields>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <objectPermissions>
@@ -87,6 +89,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>rflib_Application_Event_Archive__b</object>
+        <viewAllFields>false</viewAllFields>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <objectPermissions>
@@ -96,6 +99,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>rflib_Application_Event_Occurred_Event__e</object>
+        <viewAllFields>false</viewAllFields>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <objectPermissions>
@@ -105,6 +109,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>rflib_Application_Event__c</object>
+        <viewAllFields>true</viewAllFields>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <objectPermissions>
@@ -114,6 +119,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>rflib_Big_Object_Stat__c</object>
+        <viewAllFields>false</viewAllFields>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <objectPermissions>
@@ -123,6 +129,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>rflib_Log_Event__e</object>
+        <viewAllFields>false</viewAllFields>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <objectPermissions>
@@ -132,6 +139,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>rflib_Logs_Archive__b</object>
+        <viewAllFields>false</viewAllFields>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <tabSettings>

--- a/rflib/main/default/permissionsets/rflib_Ops_Center_Access.permissionset-meta.xml
+++ b/rflib/main/default/permissionsets/rflib_Ops_Center_Access.permissionset-meta.xml
@@ -52,16 +52,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>rflib_Application_Event__c.Additional_Details__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>rflib_Application_Event__c.Related_Record_ID__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>rflib_Logs_Archive__b.Log_Messages__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/rflib/test/default/classes/rflib_AbstractArchiveCleanupTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_AbstractArchiveCleanupTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_ApplicationEventArchiveCleanupTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_ApplicationEventArchiveCleanupTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_ApplicationEventArchiverTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_ApplicationEventArchiverTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_ApplicationEventControllerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_ApplicationEventControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_ApplicationEventLoggerActionTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_ApplicationEventLoggerActionTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_ArchiveLogActionTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_ArchiveLogActionTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_BigObjectCounterTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_BigObjectCounterTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_CollectionUtilTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_CollectionUtilTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_CustomSettingsEditorControllerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_CustomSettingsEditorControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_DatabaseDmlExecutorTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_DatabaseDmlExecutorTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_DatabaseQueryExecutorTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_DatabaseQueryExecutorTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_DefaultApplicationEventLoggerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_DefaultApplicationEventLoggerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_DefaultApplicationEventServiceTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_DefaultApplicationEventServiceTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_DefaultBigObjectDatabaseExecTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_DefaultBigObjectDatabaseExecTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_DefaultLogFinalizerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_DefaultLogFinalizerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_DefaultLogTimerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_DefaultLogTimerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_DefaultLoggerFactoryTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_DefaultLoggerFactoryTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_DefaultLoggerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_DefaultLoggerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_EventBusPublisherTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_EventBusPublisherTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_GlobalSettingsTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_GlobalSettingsTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_HttpCalloutLogActionTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_HttpCalloutLogActionTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_HttpEndpointMockerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_HttpEndpointMockerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_HttpRequestTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_HttpRequestTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_LogArchiveCleanupTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_LogArchiveCleanupTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_LogArchiveControllerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_LogArchiveControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_LogArchiveFactory.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_LogArchiveFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_LogEventViewerControllerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_LogEventViewerControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_LogLevelTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_LogLevelTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_LogTimerFlowActionTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_LogTimerFlowActionTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_LoggerControllerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_LoggerControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_LoggerFlowActionTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_LoggerFlowActionTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_LoggerUtilTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_LoggerUtilTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_MockApplicationEventLogger.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_MockApplicationEventLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_MockApplicationEventService.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_MockApplicationEventService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_MockBigObjectDatabaseExecutor.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_MockBigObjectDatabaseExecutor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_MockDmlExecutor.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_MockDmlExecutor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_MockEventPublisher.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_MockEventPublisher.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_MockLogFinalizer.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_MockLogFinalizer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_MockLogTimer.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_MockLogTimer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_MockLogger.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_MockLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_MockLoggerFactory.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_MockLoggerFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_MockQueryExecutor.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_MockQueryExecutor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_OmniStudioRemoteActionsTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_OmniStudioRemoteActionsTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_OrgUtilTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_OrgUtilTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_PermissionsExplorerControllerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_PermissionsExplorerControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_PublicGroupMemberManagerCtrlTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_PublicGroupMemberManagerCtrlTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_SOQL_Test.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_SOQL_Test.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_SendLogEventEmailActionTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_SendLogEventEmailActionTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_SimpleHttpRequestMock.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_SimpleHttpRequestMock.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_StringUtilTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_StringUtilTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_TestUserFactory.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_TestUserFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_TestUtil.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_TestUtil.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_TraceIdTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_TraceIdTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_UserPermAssignmentControllerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_UserPermAssignmentControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_UserPermSetManagerControllerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_UserPermSetManagerControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/rflib/test/default/classes/rflib_UserProfileResolverControllerTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_UserProfileResolverControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>62.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -43,7 +43,7 @@
   ],
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "62.0",
+  "sourceApiVersion": "63.0",
   "packageAliases": {
     "RFLIB": "0Ho3h000000Kz8aCAC",
     "RFLIB-FS": "0Ho3h000000KzKOCA0",


### PR DESCRIPTION
Summary

  - Added "View All Fields" permission visibility to the Permissions Explorer UI, allowing admins to track and audit this critical security permission across profiles, permission sets, and permission set
  groups
  - Enhanced CSV exports to include the View All Fields permission data
  - Improved the Permissions Explorer table UI to display View All Fields status alongside other object permissions
  - Upgrade API version to 63.0