### PR TITLE
messageInfo.useBatchReporting null pointer fix

### DIFF
--- a/rflib/main/default/classes/rflib_LoggerFlowAction.cls
+++ b/rflib/main/default/classes/rflib_LoggerFlowAction.cls
@@ -43,7 +43,7 @@ public with sharing class rflib_LoggerFlowAction {
     public static void logMessage(List<LogMessageInfo> logMessages) {
 
         for (LogMessageInfo messageInfo : logMessages) {
-            rflib_Logger logger = messageInfo.useBatchReporting ? 
+            rflib_Logger logger = messageInfo.useBatchReporting == true ? 
                 loggerFactory.createBatchedLogger(messageInfo.context) :
                 loggerFactory.createLogger(messageInfo.context);
                 


### PR DESCRIPTION
if messageInfo.useBatchReporting is null, it will trigger null pointer exception. Need explicitly compare with true/false