### PR TITLE
Add Microsoft Teams log notification support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### RFLIB 10.2.0
+
+Package ID: 04tKY0000005RTzYAM
+Package Alias: RFLIB@10.2.0-1
+Install link: https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKY0000005RTzYAM
+
+- [PR #137](https://github.com/j-fischer/rflib/pull/137) Added Slack notification support for RFLIB log events. Log events at or above a configurable threshold (minimum WARN) are forwarded to a Slack channel via the `Send_Log_Event_to_Slack` flow, with the Slack log level controlled by the new `Slack_Log_Level__c` setting and the maximum notifications per invocation configurable as a Global Config value. Log messages are truncated from the beginning and include the Org Name in the Slack payload.
+
 ### RFLIB 10.1.1
 
 Package ID: 04tKY0000009yQwYAI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### RFLIB 10.3.0
+
+- Added Microsoft Teams notification support for RFLIB log events. Log events at or above a configurable threshold (minimum WARN) are forwarded to a Teams channel via the `Send_Log_Event_to_Teams` flow action, with the Teams log level controlled by the new `Teams_Log_Level__c` setting and the maximum notifications per invocation configurable as a Global Config value (`Max_Teams_Notifications_Per_Invocation`). Requires a Named Credential named `RFLIB_TEAMS_WEBHOOK` configured with a Microsoft Teams Incoming Webhook (Power Automate Workflow or legacy Office 365 connector). The payload is an Adaptive Card containing the Org Name, log level, context, request ID, log messages, and platform info; long log messages are truncated from the beginning to preserve the trailing exception detail.
+
 ### RFLIB 10.2.0
 
 Package ID: 04tKY0000005RTzYAM

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ sf package install --package <Package ID> --target-org <your org alias>
 Here are the commands for the latest versions:
 
 ```
-rem RFLIB 10.1.1
-sf package install --package 04tKY0000009yQwYAI --target-org <your org alias>
+rem RFLIB 10.2.0
+sf package install --package 04tKY0000005RTzYAM --target-org <your org alias>
 
 rem RFLIB-FS 3.0.1
 sf package install --package 04t3h000004pOeLAAU --target-org <your org alias>

--- a/rflib/main/default/classes/rflib_GlobalSettings.cls
+++ b/rflib/main/default/classes/rflib_GlobalSettings.cls
@@ -94,6 +94,9 @@ public class rflib_GlobalSettings {
     @TestVisible
     private static final Integer MAX_SLACK_NOTIFICATIONS_PER_INVOCATION_DEFAULT_VALUE = 20;
 
+    @TestVisible
+    private static final Integer MAX_TEAMS_NOTIFICATIONS_PER_INVOCATION_DEFAULT_VALUE = 20;
+
     public static Integer daysToRetainApplicationEventsOrDefault {
         get {
             String val = getSetting('Application_Event_Retain_X_Days');
@@ -224,6 +227,13 @@ public class rflib_GlobalSettings {
         get {
             String val = getSetting('Max_Slack_Notifications_Per_Invocation');
             return String.isBlank(val) ? MAX_SLACK_NOTIFICATIONS_PER_INVOCATION_DEFAULT_VALUE : Integer.valueOf(val);
+        }
+    }
+
+    public static Integer maxTeamsNotificationsPerInvocationOrDefault {
+        get {
+            String val = getSetting('Max_Teams_Notifications_Per_Invocation');
+            return String.isBlank(val) ? MAX_TEAMS_NOTIFICATIONS_PER_INVOCATION_DEFAULT_VALUE : Integer.valueOf(val);
         }
     }
 

--- a/rflib/main/default/classes/rflib_SendLogEventTeamsAction.cls
+++ b/rflib/main/default/classes/rflib_SendLogEventTeamsAction.cls
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2024 Johannes Fischer <fischer.jh@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name "RFLIB", the name of the copyright holder, nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @group Logger
+ * @description Invocable Action that sends log event details to a Microsoft Teams channel via
+ *              an Incoming Webhook (Power Automate Workflow or legacy Office 365 connector).
+ *              Configure a Named Credential named RFLIB_TEAMS_WEBHOOK with the Teams webhook
+ *              URL (Authentication Protocol: No Authentication). Set Teams_Log_Level__c in the
+ *              Logger Settings to control which events trigger a notification.
+ */
+@SuppressWarnings('PMD.ClassNamingConventions')
+public with sharing class rflib_SendLogEventTeamsAction {
+
+    private static final rflib_Logger LOGGER = rflib_LoggerUtil.getFactory().createLogger('rflib_SendLogEventTeamsAction');
+
+    private static final rflib_ApplicationEventLogger APP_EVENT_LOGGER = rflib_LoggerUtil.getApplicationEventLogger();
+
+    @TestVisible
+    private static final String ENDPOINT = 'callout:RFLIB_TEAMS_WEBHOOK';
+
+    // Adaptive Cards in Teams have a 28KB total payload limit; cap per-block text to keep total payload safe.
+    private static final Integer MAX_BLOCK_TEXT_LENGTH = 2800;
+
+    // INFO and below are never appropriate for Teams alerting; enforce WARN as the floor.
+    @TestVisible
+    private static final rflib_LogLevel MINIMUM_LOG_LEVEL = rflib_LogLevel.WARN;
+
+    static {
+        // NOTE: It is critical to turn reporting off so that a log configuration reporting INFO statements
+        //       does not create an infinite loop of log events.
+        LOGGER.setReportingLogLevel(rflib_LogLevel.NONE);
+        LOGGER.setSystemDebugLevel(rflib_LogLevel.DEBUG);
+    }
+
+    @InvocableMethod(label='Send Log Event to Microsoft Teams' category='RFLIB' description='Send Log Events to a Microsoft Teams channel via Incoming Webhook')
+    public static void sendToTeams(List<rflib_Log_Event__e> events) {
+        try {
+            rflib_Logger_Settings__c loggerSettings = rflib_Logger_Settings__c.getInstance();
+            Integer maxNotifications = rflib_GlobalSettings.maxTeamsNotificationsPerInvocationOrDefault;
+            Integer sent = 0;
+
+            for (rflib_Log_Event__e evt : events) {
+                if (sent >= maxNotifications) {
+                    LOGGER.warn('Max Teams notifications per invocation (' + maxNotifications + ') reached; remaining events skipped.');
+                    break;
+                }
+                if (matchesConfiguredLogLevel(loggerSettings, evt)) {
+                    sendMessage(evt);
+                    sent++;
+                }
+            }
+        } catch (Exception ex) {
+            LOGGER.error('Failed to send log event(s) to Teams', ex);
+            APP_EVENT_LOGGER.logApplicationEvent('rflib-teams-log-event-failed', null, LOGGER.printLogs());
+        }
+    }
+
+    private static Boolean matchesConfiguredLogLevel(rflib_Logger_Settings__c loggerSettings, rflib_Log_Event__e evt) {
+        rflib_LogLevel configuredLevel = rflib_LogLevel.fromString(loggerSettings.Teams_Log_Level__c);
+
+        // NONE means disabled; skip the floor check so it stays disabled.
+        // For any level below WARN (INFO, DEBUG, TRACE), clamp up to WARN.
+        // encompasses() returns false when either side is NONE, so we guard that first.
+        if (configuredLevel != rflib_LogLevel.NONE && !MINIMUM_LOG_LEVEL.encompasses(configuredLevel)) {
+            LOGGER.warn('Teams_Log_Level__c is configured below the minimum of WARN. Clamping to WARN.');
+            configuredLevel = MINIMUM_LOG_LEVEL;
+        }
+
+        return configuredLevel.encompasses(rflib_LogLevel.fromString(evt.Log_Level__c));
+    }
+
+    private static void sendMessage(rflib_Log_Event__e evt) {
+        try {
+            rflib_HttpRequest req = new rflib_HttpRequest(LOGGER);
+            req.setEndpoint(ENDPOINT);
+            req.setMethod('POST');
+            req.setHeader('Content-Type', 'application/json');
+            req.setBody(createTeamsPayload(evt));
+
+            HttpResponse res = req.send();
+            // Power Automate Workflow webhooks return 202 Accepted; legacy O365 connectors return 200.
+            if (res.getStatusCode() == 200 || res.getStatusCode() == 202) {
+                LOGGER.debug('Successfully sent log event to Teams for context: ' + evt.Context__c);
+            } else {
+                LOGGER.debug('Failed to send log event to Teams. Status: ' + res.getStatus() + ' for context: ' + evt.Context__c);
+                APP_EVENT_LOGGER.logApplicationEvent('rflib-teams-log-event-failed', null, JSON.serialize(res));
+            }
+        } catch (Exception ex) {
+            LOGGER.error('Failed to send log event to Teams for context: ' + evt.Context__c, ex);
+            APP_EVENT_LOGGER.logApplicationEvent('rflib-teams-log-event-failed', null, LOGGER.printLogs());
+        }
+    }
+
+    @TestVisible
+    private static String createTeamsPayload(rflib_Log_Event__e evt) {
+        String logMessages = truncate(evt.Log_Messages__c, MAX_BLOCK_TEXT_LENGTH);
+        String platformInfo = truncate(getFormattedPlatformInfo(evt), MAX_BLOCK_TEXT_LENGTH);
+
+        List<Object> body = new List<Object>{
+            createHeaderTextBlock('RFLIB Log Event – ' + evt.Log_Level__c),
+            createMetadataFactSet(evt),
+            createLabelTextBlock('Log Messages:'),
+            createMonospaceTextBlock(logMessages),
+            createLabelTextBlock('Platform Info:'),
+            createMonospaceTextBlock(platformInfo)
+        };
+
+        Map<String, Object> adaptiveCard = new Map<String, Object>{
+            '$schema' => 'http://adaptivecards.io/schemas/adaptive-card.json',
+            'type' => 'AdaptiveCard',
+            'version' => '1.4',
+            'body' => body
+        };
+
+        Map<String, Object> attachment = new Map<String, Object>{
+            'contentType' => 'application/vnd.microsoft.card.adaptive',
+            'contentUrl' => null,
+            'content' => adaptiveCard
+        };
+
+        return JSON.serialize(new Map<String, Object>{
+            'type' => 'message',
+            'attachments' => new List<Object>{ attachment }
+        });
+    }
+
+    private static Map<String, Object> createHeaderTextBlock(String text) {
+        return new Map<String, Object>{
+            'type' => 'TextBlock',
+            'size' => 'Large',
+            'weight' => 'Bolder',
+            'wrap' => true,
+            'text' => text
+        };
+    }
+
+    private static Map<String, Object> createMetadataFactSet(rflib_Log_Event__e evt) {
+        return new Map<String, Object>{
+            'type' => 'FactSet',
+            'facts' => new List<Object>{
+                createFact('Org Name:', UserInfo.getOrganizationName()),
+                createFact('Log Level:', evt.Log_Level__c),
+                createFact('Created By:', evt.CreatedById),
+                createFact('Context:', evt.Context__c),
+                createFact('Request ID:', evt.Request_ID__c)
+            }
+        };
+    }
+
+    private static Map<String, Object> createLabelTextBlock(String text) {
+        return new Map<String, Object>{
+            'type' => 'TextBlock',
+            'weight' => 'Bolder',
+            'separator' => true,
+            'wrap' => true,
+            'text' => text
+        };
+    }
+
+    private static Map<String, Object> createMonospaceTextBlock(String text) {
+        return new Map<String, Object>{
+            'type' => 'TextBlock',
+            'fontType' => 'Monospace',
+            'wrap' => true,
+            'text' => text
+        };
+    }
+
+    private static Map<String, Object> createFact(String title, String value) {
+        return new Map<String, Object>{
+            'title' => title,
+            'value' => value
+        };
+    }
+
+    private static String truncate(String value, Integer maxLength) {
+        if (String.isBlank(value)) {
+            return 'N/A';
+        }
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return '[TRUNCATED]\n' + value.right(maxLength);
+    }
+
+    private static String getFormattedPlatformInfo(rflib_Log_Event__e evt) {
+        if (String.isBlank(evt.Platform_Info__c)) {
+            return 'N/A';
+        }
+        try {
+            return JSON.serializePretty(JSON.deserializeUntyped(evt.Platform_Info__c));
+        } catch (Exception ex) {
+            return evt.Platform_Info__c;
+        }
+    }
+}

--- a/rflib/main/default/classes/rflib_SendLogEventTeamsAction.cls-meta.xml
+++ b/rflib/main/default/classes/rflib_SendLogEventTeamsAction.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rflib/main/default/flows/rflib_Log_Event_Handler.flow-meta.xml
+++ b/rflib/main/default/flows/rflib_Log_Event_Handler.flow-meta.xml
@@ -5,7 +5,7 @@
         <name>Archive_Log_Event</name>
         <label>Archive Log Event</label>
         <locationX>176</locationX>
-        <locationY>386</locationY>
+        <locationY>494</locationY>
         <actionName>rflib_ArchiveLogAction</actionName>
         <actionType>apex</actionType>
         <connector>
@@ -61,6 +61,32 @@ Runs in a new transaction to ensure governor limit isolation from the preceding 
         <actionName>rflib_SendLogEventSlackAction</actionName>
         <actionType>apex</actionType>
         <connector>
+            <targetReference>Send_Log_Event_to_Teams</targetReference>
+        </connector>
+        <faultConnector>
+            <isGoTo>true</isGoTo>
+            <targetReference>Send_Log_Event_to_Teams</targetReference>
+        </faultConnector>
+        <flowTransactionModel>NewTransaction</flowTransactionModel>
+        <inputParameters>
+            <name>events</name>
+            <value>
+                <elementReference>$Record</elementReference>
+            </value>
+        </inputParameters>
+        <nameSegment>rflib_SendLogEventSlackAction</nameSegment>
+        <offset>0</offset>
+    </actionCalls>
+    <actionCalls>
+        <description>Sends the Log Event to a Microsoft Teams channel via Incoming Webhook. Requires a Named Credential named RFLIB_TEAMS_WEBHOOK and Teams_Log_Level__c to be configured in the Logger Settings.
+Runs in a new transaction to ensure governor limit isolation from the preceding HTTP callout action.</description>
+        <name>Send_Log_Event_to_Teams</name>
+        <label>Send Log Event to Teams</label>
+        <locationX>176</locationX>
+        <locationY>386</locationY>
+        <actionName>rflib_SendLogEventTeamsAction</actionName>
+        <actionType>apex</actionType>
+        <connector>
             <targetReference>Archive_Log_Event</targetReference>
         </connector>
         <faultConnector>
@@ -74,7 +100,7 @@ Runs in a new transaction to ensure governor limit isolation from the preceding 
                 <elementReference>$Record</elementReference>
             </value>
         </inputParameters>
-        <nameSegment>rflib_SendLogEventSlackAction</nameSegment>
+        <nameSegment>rflib_SendLogEventTeamsAction</nameSegment>
         <offset>0</offset>
     </actionCalls>
     <actionCalls>
@@ -82,7 +108,7 @@ Runs in a new transaction to ensure governor limit isolation from the preceding 
         <name>rflib_Send_Log_Event_Emails</name>
         <label>Send Log Event Emails</label>
         <locationX>176</locationX>
-        <locationY>494</locationY>
+        <locationY>602</locationY>
         <actionName>rflib_SendLogEventEmailAction</actionName>
         <actionType>apex</actionType>
         <flowTransactionModel>CurrentTransaction</flowTransactionModel>

--- a/rflib/main/default/labels/CustomLabels.labels-meta.xml
+++ b/rflib/main/default/labels/CustomLabels.labels-meta.xml
@@ -6,6 +6,6 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>RFLIB Version</shortDescription>
-        <value>10.1.1</value>
+        <value>10.2.0</value>
     </labels>
 </CustomLabels>

--- a/rflib/main/default/objects/rflib_Global_Setting__mdt/validationRules/Max_Teams_Notifications_Must_Be_Number.validationRule-meta.xml
+++ b/rflib/main/default/objects/rflib_Global_Setting__mdt/validationRules/Max_Teams_Notifications_Must_Be_Number.validationRule-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Max_Teams_Notifications_Must_Be_Number</fullName>
+    <active>true</active>
+    <description>Max_Teams_Notifications_Per_Invocation value must be a positive number no greater than 100.</description>
+    <errorConditionFormula>DeveloperName = &apos;Max_Teams_Notifications_Per_Invocation&apos; &amp;&amp;
+OR(
+  NOT(ISNUMBER( Value__c )),
+  VALUE( Value__c ) &lt; 1,
+  VALUE( Value__c ) &gt; 100
+)</errorConditionFormula>
+    <errorDisplayField>Value__c</errorDisplayField>
+    <errorMessage>The value for Max Teams Notifications Per Invocation must be a number between 1 and 100.</errorMessage>
+</ValidationRule>

--- a/rflib/main/default/objects/rflib_Logger_Settings__c/fields/Teams_Log_Level__c.field-meta.xml
+++ b/rflib/main/default/objects/rflib_Logger_Settings__c/fields/Teams_Log_Level__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Teams_Log_Level__c</fullName>
+    <defaultValue>&quot;NONE&quot;</defaultValue>
+    <description>Set the log level for which a Microsoft Teams notification will be sent in response to a Log Event. Whenever a Log Event is created and the level of the event is encompassed by the currently set Teams Log Level, a message is posted to the configured Teams channel. Requires a Named Credential named RFLIB_TEAMS_WEBHOOK to be configured with the Microsoft Teams Incoming Webhook URL (Power Automate Workflow or legacy Office 365 connector). INFO and below are never sent to Teams regardless of this setting; WARN is the enforced minimum.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Set the log level for which Microsoft Teams notifications are sent in response to a Log Event. Valid values are NONE, WARN, ERROR, and FATAL. WARN is the minimum enforced level — INFO, DEBUG, and TRACE events are never sent to Teams. Requires a Named Credential named RFLIB_TEAMS_WEBHOOK.</inlineHelpText>
+    <label>Teams Log Level</label>
+    <length>5</length>
+    <required>true</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
+++ b/rflib/test/default/classes/rflib_GlobalSettingsTest.cls
@@ -261,6 +261,18 @@ private class rflib_GlobalSettingsTest {
         Test.stopTest();
     }
 
+    @IsTest
+    static void testMaxTeamsNotificationsPerInvocationOrDefault() {
+        Integer expectedValue = getConfiguredIntegerValueOrDefault(
+            'Max_Teams_Notifications_Per_Invocation',
+            rflib_GlobalSettings.MAX_TEAMS_NOTIFICATIONS_PER_INVOCATION_DEFAULT_VALUE
+        );
+
+        Test.startTest();
+        System.assertEquals(expectedValue, rflib_GlobalSettings.maxTeamsNotificationsPerInvocationOrDefault);
+        Test.stopTest();
+    }
+
     private static String getConfiguredStringValueOrDefault(String settingName, String defaultValue) {
         String value = rflib_Global_Setting__mdt.getInstance(settingName)?.Value__c;
 

--- a/rflib/test/default/classes/rflib_SendLogEventTeamsActionTest.cls
+++ b/rflib/test/default/classes/rflib_SendLogEventTeamsActionTest.cls
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2024 Johannes Fischer <fischer.jh@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name "RFLIB", the name of the copyright holder, nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+@IsTest
+@SuppressWarnings('PMD.ClassNamingConventions')
+private class rflib_SendLogEventTeamsActionTest {
+
+    private static final String SUCCESS_RESPONSE = '';
+    private static final String ERROR_RESPONSE = 'Bad Request';
+    private static final String METHOD = 'POST';
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testSendToTeams_Success() {
+        setupLoggerSettings('ERROR');
+
+        List<rflib_Log_Event__e> events = createTestLogEvents('ERROR');
+        HttpRequest req = createMockRequest(events[0]);
+        HttpResponse resp = createSuccessResponse();
+
+        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req, resp));
+
+        Test.startTest();
+        rflib_SendLogEventTeamsAction.sendToTeams(events);
+        Test.stopTest();
+
+        Assert.areEqual(0, [SELECT COUNT() FROM rflib_Application_Event__c WHERE Event_Name__c = 'rflib-teams-log-event-failed']);
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testSendToTeams_LogLevelDoesNotMatch() {
+        setupLoggerSettings('WARN');
+
+        Test.startTest();
+        rflib_SendLogEventTeamsAction.sendToTeams(createTestLogEvents('INFO'));
+        Test.stopTest();
+
+        Assert.areEqual(0, [SELECT COUNT() FROM rflib_Application_Event__c WHERE Event_Name__c = 'rflib-teams-log-event-failed']);
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testSendToTeams_LogLevelNone() {
+        setupLoggerSettings('NONE');
+
+        Test.startTest();
+        rflib_SendLogEventTeamsAction.sendToTeams(createTestLogEvents('FATAL'));
+        Test.stopTest();
+
+        Assert.areEqual(0, [SELECT COUNT() FROM rflib_Application_Event__c WHERE Event_Name__c = 'rflib-teams-log-event-failed']);
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testSendToTeams_FailureResponse() {
+        setupLoggerSettings('ERROR');
+
+        List<rflib_Log_Event__e> events = createTestLogEvents('ERROR');
+        HttpRequest req = createMockRequest(events[0]);
+        HttpResponse resp = createErrorResponse();
+
+        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req, resp));
+
+        Test.startTest();
+        rflib_SendLogEventTeamsAction.sendToTeams(events);
+        Test.stopTest();
+
+        Assert.areEqual(1, [SELECT COUNT() FROM rflib_Application_Event__c WHERE Event_Name__c = 'rflib-teams-log-event-failed']);
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testSendToTeams_ThrowsException() {
+        setupLoggerSettings('ERROR');
+
+        List<rflib_Log_Event__e> events = createTestLogEvents('ERROR');
+        HttpRequest req = createMockRequest(events[0]);
+        CalloutException ex = new CalloutException('Teams webhook callout failed');
+
+        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req, ex));
+
+        Test.startTest();
+        rflib_SendLogEventTeamsAction.sendToTeams(events);
+        Test.stopTest();
+
+        Assert.areEqual(1, [SELECT COUNT() FROM rflib_Application_Event__c WHERE Event_Name__c = 'rflib-teams-log-event-failed']);
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testSendToTeams_LongMessageTruncated() {
+        setupLoggerSettings('ERROR');
+
+        String longMessage = 'X'.repeat(5000);
+        List<rflib_Log_Event__e> events = new List<rflib_Log_Event__e>{
+            new rflib_Log_Event__e(
+                Log_Level__c = 'ERROR',
+                Context__c = 'TestContext',
+                Request_ID__c = 'TestRequestId',
+                Log_Messages__c = longMessage,
+                Platform_Info__c = '{"CPU Time":12,"Heap Size":4080}'
+            )
+        };
+
+        HttpRequest req = createMockRequest(events[0]);
+        HttpResponse resp = createSuccessResponse();
+
+        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req, resp));
+
+        Test.startTest();
+        rflib_SendLogEventTeamsAction.sendToTeams(events);
+        Test.stopTest();
+
+        Assert.areEqual(0, [SELECT COUNT() FROM rflib_Application_Event__c WHERE Event_Name__c = 'rflib-teams-log-event-failed']);
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testSendToTeams_InfoLevelConfigured_InfoEventNotSent() {
+        setupLoggerSettings('INFO');
+
+        Test.startTest();
+        rflib_SendLogEventTeamsAction.sendToTeams(createTestLogEvents('INFO'));
+        Test.stopTest();
+
+        Assert.areEqual(0, [SELECT COUNT() FROM rflib_Application_Event__c WHERE Event_Name__c = 'rflib-teams-log-event-failed']);
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testSendToTeams_InfoLevelConfigured_WarnEventSentAtWarnFloor() {
+        setupLoggerSettings('INFO');
+
+        List<rflib_Log_Event__e> events = createTestLogEvents('WARN');
+        HttpRequest req = createMockRequest(events[0]);
+        HttpResponse resp = createSuccessResponse();
+        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req, resp));
+
+        Test.startTest();
+        rflib_SendLogEventTeamsAction.sendToTeams(events);
+        Test.stopTest();
+
+        Assert.areEqual(0, [SELECT COUNT() FROM rflib_Application_Event__c WHERE Event_Name__c = 'rflib-teams-log-event-failed']);
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testSendToTeams_ExceedsMaxNotifications() {
+        setupLoggerSettings('ERROR');
+        rflib_GlobalSettings.SETTINGS.put('Max_Teams_Notifications_Per_Invocation', '1');
+
+        List<rflib_Log_Event__e> events = new List<rflib_Log_Event__e>{
+            createTestLogEvents('ERROR')[0],
+            createTestLogEvents('ERROR')[0]
+        };
+        HttpRequest req = createMockRequest(events[0]);
+        HttpResponse resp = createSuccessResponse();
+        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req, resp));
+
+        Test.startTest();
+        rflib_SendLogEventTeamsAction.sendToTeams(events);
+        Integer calloutsUsed = Limits.getCallouts();
+        Test.stopTest();
+
+        Assert.areEqual(1, calloutsUsed, 'Only 1 callout should have been made due to the cap');
+        Assert.areEqual(0, [SELECT COUNT() FROM rflib_Application_Event__c WHERE Event_Name__c = 'rflib-teams-log-event-failed']);
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testCreateTeamsPayload_WithPlatformInfo() {
+        rflib_Log_Event__e evt = new rflib_Log_Event__e(
+            Log_Level__c = 'ERROR',
+            Context__c = 'TestContext',
+            Request_ID__c = 'TestRequestId',
+            Log_Messages__c = 'Test log message',
+            Platform_Info__c = '{"CPU Time":12,"Heap Size":4080}'
+        );
+
+        Test.startTest();
+        String payload = rflib_SendLogEventTeamsAction.createTeamsPayload(evt);
+        Test.stopTest();
+
+        Assert.isTrue(payload.contains('RFLIB Log Event'), 'Payload should contain the header text');
+        Assert.isTrue(payload.contains('AdaptiveCard'), 'Payload should be an Adaptive Card');
+        Assert.isTrue(payload.contains('ERROR'), 'Payload should contain the log level');
+        Assert.isTrue(payload.contains('TestContext'), 'Payload should contain the context');
+        Assert.isTrue(payload.contains('TestRequestId'), 'Payload should contain the request ID');
+        Assert.isTrue(payload.contains('Test log message'), 'Payload should contain the log messages');
+        Assert.isTrue(payload.contains('CPU Time'), 'Payload should contain the platform info');
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testCreateTeamsPayload_LongMessageTruncatedFromBeginning() {
+        String beginning = 'BEGINNING_MARKER';
+        String tail = 'EXCEPTION_HERE';
+        rflib_Log_Event__e evt = new rflib_Log_Event__e(
+            Log_Level__c = 'ERROR',
+            Context__c = 'TestContext',
+            Request_ID__c = 'TestRequestId',
+            Log_Messages__c = beginning + 'X'.repeat(5000) + tail,
+            Platform_Info__c = null
+        );
+
+        Test.startTest();
+        String payload = rflib_SendLogEventTeamsAction.createTeamsPayload(evt);
+        Test.stopTest();
+
+        Assert.isTrue(payload.contains('[TRUNCATED]'), 'Payload should contain the truncation marker');
+        Assert.isTrue(payload.contains(tail), 'Payload should preserve the end of the log message where exceptions appear');
+        Assert.isFalse(payload.contains(beginning), 'Payload should have dropped the beginning of the message');
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testCreateTeamsPayload_WithoutPlatformInfo() {
+        rflib_Log_Event__e evt = new rflib_Log_Event__e(
+            Log_Level__c = 'WARN',
+            Context__c = 'TestContext',
+            Request_ID__c = 'TestRequestId',
+            Log_Messages__c = 'Test log message',
+            Platform_Info__c = null
+        );
+
+        Test.startTest();
+        String payload = rflib_SendLogEventTeamsAction.createTeamsPayload(evt);
+        Test.stopTest();
+
+        Assert.isTrue(payload.contains('N/A'), 'Payload should contain N/A for missing platform info');
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testCreateTeamsPayload_WithNonJsonPlatformInfo() {
+        rflib_Log_Event__e evt = new rflib_Log_Event__e(
+            Log_Level__c = 'WARN',
+            Context__c = 'TestContext',
+            Request_ID__c = 'TestRequestId',
+            Log_Messages__c = 'Test log message',
+            Platform_Info__c = 'N/A'
+        );
+
+        Test.startTest();
+        String payload = rflib_SendLogEventTeamsAction.createTeamsPayload(evt);
+        Test.stopTest();
+
+        Assert.isTrue(payload.contains('N/A'), 'Payload should contain the raw platform info value when it is not JSON');
+    }
+
+    @IsTest
+    @SuppressWarnings('PMD.MethodNamingConventions')
+    private static void testSendToTeams_AcceptsAcceptedResponse() {
+        setupLoggerSettings('ERROR');
+
+        List<rflib_Log_Event__e> events = createTestLogEvents('ERROR');
+        HttpRequest req = createMockRequest(events[0]);
+        HttpResponse resp = new HttpResponse();
+        resp.setStatusCode(202);
+        resp.setBody(SUCCESS_RESPONSE);
+
+        Test.setMock(HttpCalloutMock.class, new rflib_SimpleHttpRequestMock(req, resp));
+
+        Test.startTest();
+        rflib_SendLogEventTeamsAction.sendToTeams(events);
+        Test.stopTest();
+
+        Assert.areEqual(0, [SELECT COUNT() FROM rflib_Application_Event__c WHERE Event_Name__c = 'rflib-teams-log-event-failed']);
+    }
+
+    private static List<rflib_Log_Event__e> createTestLogEvents(String logLevel) {
+        return new List<rflib_Log_Event__e>{
+            new rflib_Log_Event__e(
+                Log_Level__c = logLevel,
+                Context__c = 'TestContext',
+                Request_ID__c = 'TestRequestId',
+                Log_Messages__c = 'Test log message',
+                Platform_Info__c = '{"CPU Time":12,"Heap Size":4080}'
+            )
+        };
+    }
+
+    private static HttpRequest createMockRequest(rflib_Log_Event__e evt) {
+        HttpRequest req = new HttpRequest();
+        req.setEndpoint(rflib_SendLogEventTeamsAction.ENDPOINT);
+        req.setMethod(METHOD);
+        req.setHeader('Content-Type', 'application/json');
+        req.setBody(rflib_SendLogEventTeamsAction.createTeamsPayload(evt));
+        return req;
+    }
+
+    private static HttpResponse createSuccessResponse() {
+        HttpResponse response = new HttpResponse();
+        response.setStatusCode(200);
+        response.setBody(SUCCESS_RESPONSE);
+        return response;
+    }
+
+    private static HttpResponse createErrorResponse() {
+        HttpResponse response = new HttpResponse();
+        response.setStatusCode(400);
+        response.setBody(ERROR_RESPONSE);
+        return response;
+    }
+
+    private static void setupLoggerSettings(String teamsLogLevel) {
+        rflib_Logger_Settings__c loggerSettings = rflib_Logger_Settings__c.getInstance();
+        loggerSettings.Teams_Log_Level__c = teamsLogLevel;
+        insert loggerSettings;
+    }
+}

--- a/rflib/test/default/classes/rflib_SendLogEventTeamsActionTest.cls-meta.xml
+++ b/rflib/test/default/classes/rflib_SendLogEventTeamsActionTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
       "path": "rflib",
       "default": true,
       "package": "RFLIB",
-      "versionName": "ver 10.1.1",
-      "versionNumber": "10.1.1.NEXT",
+      "versionName": "ver 10.2.0",
+      "versionNumber": "10.2.0.NEXT",
       "postInstallUrl": "https://github.com/j-fischer/rflib#how-tos",
       "releaseNotesUrl": "https://github.com/j-fischer/rflib/blob/master/CHANGELOG.md",
       "versionDescription": "Open source library with logging framework and advanced monitoring capabilities. License: BSD-3-Clause."
@@ -166,6 +166,7 @@
     "RFLIB-PHAROS@1.0.0-5": "04tKY000000xhxmYAA",
     "RFLIB@10.1.0-1": "04tKY000000ygWuYAI",
     "RFLIB-TF@3.1.0-1": "04tKY0000009yMKYAY",
-    "RFLIB@10.1.1-1": "04tKY0000009yQwYAI"
+    "RFLIB@10.1.1-1": "04tKY0000009yQwYAI",
+    "RFLIB@10.2.0-1": "04tKY0000005RTzYAM"
   }
 }


### PR DESCRIPTION
## Summary

- Mirrors the Slack log-notification feature for Microsoft Teams: log events at or above a configurable threshold (minimum WARN) are forwarded to a Teams channel via a new `Send_Log_Event_to_Teams` invocable action, wired into the `rflib_Log_Event_Handler` flow between Slack and Archive (NewTransaction, same isolation pattern as Slack).
- New `Teams_Log_Level__c` field on `rflib_Logger_Settings__c` (default `NONE`, WARN-floor enforcement), new `Max_Teams_Notifications_Per_Invocation` Global Config value (default 20, validated 1–100), and `maxTeamsNotificationsPerInvocationOrDefault` accessor on `rflib_GlobalSettings`.
- Payload is an Adaptive Card 1.4 wrapped in the Workflows-for-Teams message envelope (`type: message` → `attachments` → `contentType: application/vnd.microsoft.card.adaptive`). Accepts both `200` (legacy O365 connector) and `202` (modern Power Automate Workflow webhook) as success, easing the May 2026 connector retirement. Requires a Named Credential `RFLIB_TEAMS_WEBHOOK`.

## Test plan

- [ ] `sf apex run test -n rflib_SendLogEventTeamsActionTest --code-coverage` passes with ≥90% coverage on the new class
- [ ] `sf apex run test -n rflib_GlobalSettingsTest` still passes (added `testMaxTeamsNotificationsPerInvocationOrDefault`)
- [ ] Deploy to a scratch org, configure `RFLIB_TEAMS_WEBHOOK` Named Credential against a Teams Workflow webhook, set `Teams_Log_Level__c = WARN`, emit a WARN log event, confirm the Adaptive Card lands in the target channel with Org Name, Log Level, Context, Request ID, log messages, and platform info
- [ ] Set `Teams_Log_Level__c = NONE`, emit a FATAL event, confirm no Teams notification fires
- [ ] Emit a log message > 2800 chars and confirm the card shows `[TRUNCATED]` and preserves the tail
- [ ] Configure `Max_Teams_Notifications_Per_Invocation = 1`, publish two qualifying events in one transaction, confirm only one Teams callout occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)