### PR TITLE
test(rflib): add Playwright E2E test suite for Ops Center

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,7 @@ jobs:
                   command: |
                       npx sf org delete scratch -o ciorg -p
                   when: on_fail
+
     report_coverage:
         <<: *defaults
         steps:
@@ -197,6 +198,7 @@ jobs:
                       bash <(curl -s https://codecov.io/bash)
                       rm -f test-result-codecoverage.json
                       node_modules/codecov/bin/codecov
+
     scan_flows:
         <<: *defaults
         steps:
@@ -242,10 +244,10 @@ workflows:
             - run_apex_tests:
                   requires:
                       - deploy_source
-            # Runs after the Apex tests so only one job uses the scratch org at a time
+
             - run_e2e_tests:
                   requires:
-                      - run_apex_tests
+                      - deploy_source
             - report_coverage:
                   requires:
                       - run_apex_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,4 +257,5 @@ workflows:
                           only: master
             - cleanup_scratch_org:
                   requires:
+                      - run_apex_tests
                       - run_e2e_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,40 @@ jobs:
                   name: Run LWC Tests
                   command: |
                       npm run test:unit:coverage
+
+    run_e2e_tests:
+        <<: *defaults
+        steps:
+            - attach_workspace:
+                  at: ~/
+            - run:
+                  name: Install Dependencies
+                  command: npm install
+            - run:
+                  name: Install Playwright Browser
+                  command: |
+                      npx playwright install --with-deps chromium
+            - run:
+                  name: Assign Permission Sets
+                  command: |
+                      npx sf org assign permset --name rflib_Ops_Center_Access --name rflib_Create_Application_Event --target-org ciorg
+            - run:
+                  name: Run E2E Tests
+                  no_output_timeout: 30m
+                  command: |
+                      export RFLIB_E2E_TARGET_ORG=ciorg
+                      npx playwright test
+            - store_artifacts:
+                  path: playwright-report
+                  destination: playwright-report
+            - store_artifacts:
+                  path: test-results
+                  destination: test-results
+            - run:
+                  name: Clean Up
+                  command: |
+                      npx sf org delete scratch -o ciorg -p
+                  when: on_fail
     report_coverage:
         <<: *defaults
         steps:
@@ -208,6 +242,10 @@ workflows:
             - run_apex_tests:
                   requires:
                       - deploy_source
+            # Runs after the Apex tests so only one job uses the scratch org at a time
+            - run_e2e_tests:
+                  requires:
+                      - run_apex_tests
             - report_coverage:
                   requires:
                       - run_apex_tests
@@ -217,4 +255,4 @@ workflows:
                           only: master
             - cleanup_scratch_org:
                   requires:
-                      - run_apex_tests
+                      - run_e2e_tests

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ CLAUDE.md
 codex.md
 AGENTS.md
 GEMINI.md
+
+# Playwright E2E tests
+playwright-report/
+test-results/
+e2e/.auth/

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,7 @@
 
 sfdx-project.json
 gulpfile.js
+
+playwright-report
+test-results
+e2e/.auth

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -98,3 +98,7 @@ closeviewer
 Vabu
 rowaction
 lookback
+frontdoor
+domcontentloaded
+menuitemcheckbox
+runnability

--- a/cspell.json
+++ b/cspell.json
@@ -37,7 +37,10 @@
         "gulpfile.js",
         "package*.json",
         "CHANGELOG.md",
-        ".aidigest*"
+        ".aidigest*",
+        "**/playwright-report/**",
+        "**/test-results/**",
+        "e2e/.auth/**"
     ],
     "ignoreWords": ["commitcomment"],
     "ignoreRegExpList": ["/sf package install --package [\\w]{15,18} --target-org .*/g"]

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,26 @@
+import { Browser, BrowserContext, Page } from '@playwright/test';
+import { OpsCenterApp } from './pages/ops-center-app.page';
+import { STORAGE_STATE_PATH } from './helpers/sf';
+
+export interface OpsCenterSession {
+    context: BrowserContext;
+    page: Page;
+    app: OpsCenterApp;
+}
+
+// Creates a shared page for a spec file (used from beforeAll, so the App Launcher
+// flow runs once per file). Contexts created in beforeAll do not inherit the
+// config "use" options, so storageState and viewport are passed explicitly.
+export async function createOpsCenterSession(browser: Browser, tabLabel?: string): Promise<OpsCenterSession> {
+    const context = await browser.newContext({
+        storageState: STORAGE_STATE_PATH,
+        viewport: { width: 1600, height: 900 }
+    });
+    const page = await context.newPage();
+    const app = new OpsCenterApp(page);
+    await app.openViaAppLauncher();
+    if (tabLabel) {
+        await app.gotoTab(tabLabel);
+    }
+    return { context, page, app };
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,39 @@
+import { chromium } from '@playwright/test';
+import { runApex, saveOrgInfo, sfJson, soql, STORAGE_STATE_PATH } from './helpers/sf';
+
+export default async function globalSetup(): Promise<void> {
+    console.log('Resolving default org via sf CLI...');
+    const display = sfJson(['org', 'display']);
+    if (display.status !== 0) {
+        throw new Error(
+            `No default org found. Set one with "sf config set target-org <alias>". ${JSON.stringify(display)}`
+        );
+    }
+    const username: string = display.result.username;
+    const instanceUrl: string = display.result.instanceUrl.replace(/\/$/, '');
+    const users = soql(`SELECT Name FROM User WHERE Username = '${username}'`);
+    saveOrgInfo({ username, instanceUrl, adminName: users[0].Name });
+    console.log(`Using org ${username} at ${instanceUrl}`);
+
+    console.log('Establishing browser session via frontdoor URL...');
+    const open = sfJson(['org', 'open', '--url-only']);
+    const browser = await chromium.launch();
+    try {
+        const page = await browser.newPage();
+        await page.goto(open.result.url, { waitUntil: 'domcontentloaded' });
+        await page.waitForURL(/\/lightning\//, { timeout: 90_000 });
+        await page
+            .locator('one-appnav, header.slds-global-header_container')
+            .first()
+            .waitFor({ state: 'visible', timeout: 90_000 });
+        await page.context().storageState({ path: STORAGE_STATE_PATH });
+    } finally {
+        await browser.close();
+    }
+
+    console.log('Seeding test data (settings must be configured before log events publish)...');
+    runApex('scripts/apex/ConfigureCustomSettings.apex');
+    runApex('scripts/apex/CreateLogEvent.apex');
+    runApex('scripts/apex/CreateApplicationEvent.apex');
+    console.log('Global setup complete.');
+}

--- a/e2e/helpers/lightning.ts
+++ b/e2e/helpers/lightning.ts
@@ -1,0 +1,92 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+export async function expectToast(page: Page, text?: string | RegExp): Promise<void> {
+    const toast = page.locator('.slds-notify_container .slds-notify, lightning-toast, .slds-notify_toast').first();
+    await expect(toast).toBeVisible({ timeout: 30_000 });
+    if (text) {
+        await expect(toast).toContainText(text);
+    }
+}
+
+export async function waitForToastsToClear(page: Page): Promise<void> {
+    await expect(page.locator('.slds-notify_container .slds-notify, lightning-toast')).toHaveCount(0, {
+        timeout: 30_000
+    });
+}
+
+// Clicks a button inside the visible modal/confirmation dialog.
+export async function clickDialogButton(page: Page, buttonLabel: string): Promise<void> {
+    const dialog = page.locator('section[role="dialog"]:visible').last();
+    await dialog.getByRole('button', { name: buttonLabel, exact: true }).click();
+}
+
+// Selects an item from a lightning-button-menu by opening it and clicking the item label.
+export async function selectMenuItem(menuButton: Locator, itemLabel: string): Promise<void> {
+    const page = menuButton.page();
+    await menuButton.click();
+    const item = page
+        .getByRole('menuitem', { name: itemLabel })
+        .or(page.getByRole('menuitemcheckbox', { name: itemLabel }))
+        .or(page.locator('lightning-menu-item').filter({ hasText: itemLabel }))
+        .first();
+    await item.click();
+}
+
+// Searches and selects a record in a lightning-record-picker.
+export async function pickRecord(picker: Locator, searchText: string, optionText?: string): Promise<void> {
+    const page = picker.page();
+    const input = picker.locator('input').first();
+    await input.click();
+    await input.fill(searchText);
+    const option = page
+        .getByRole('option', { name: optionText ?? searchText })
+        .or(picker.getByRole('option').filter({ hasText: optionText ?? searchText }))
+        .first();
+    await option.click({ timeout: 30_000 });
+}
+
+// Selects an option in a lightning-combobox by label.
+export async function selectComboboxOption(combobox: Locator, optionText: string | RegExp): Promise<Locator> {
+    await combobox.locator('button, input').first().click();
+    const option = combobox.getByRole('option', { name: optionText }).first();
+    await option.click();
+    return option;
+}
+
+// Returns the datatable row (tr) containing the given text within a scope.
+export function datatableRow(scope: Locator, text: string | RegExp): Locator {
+    return scope.locator('lightning-datatable tbody tr').filter({ hasText: text }).first();
+}
+
+// Opens the row-level action menu of a lightning-datatable row and clicks an action.
+export async function clickRowAction(row: Locator, actionLabel: string): Promise<void> {
+    const page = row.page();
+    const menuButton = row
+        .getByRole('button', { name: /show actions/i })
+        .or(row.locator('lightning-primitive-cell-actions button'))
+        .first();
+    await menuButton.click();
+    await page.getByRole('menuitem', { name: actionLabel }).first().click();
+}
+
+// Fills a lightning-input of type "datetime" (renders separate date and time inputs).
+export async function fillDateTime(dateTimeInput: Locator, dateStr: string, timeStr: string): Promise<void> {
+    const dateInput = dateTimeInput.locator('input').first();
+    await dateInput.click();
+    await dateInput.fill(dateStr);
+    await dateInput.press('Escape'); // close the calendar popup
+    const timeInput = dateTimeInput.locator('input').nth(1);
+    await timeInput.click();
+    await timeInput.fill(timeStr);
+    await timeInput.press('Escape');
+    await timeInput.press('Tab'); // blur to fire the change event
+}
+
+export async function waitForSpinners(scope: Page | Locator, timeout = 60_000): Promise<void> {
+    await expect(scope.locator('lightning-spinner')).toHaveCount(0, { timeout });
+}
+
+// Formats a Date as M/D/YYYY (en-US scratch org default locale).
+export function formatDateUs(date: Date): string {
+    return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
+}

--- a/e2e/helpers/polling.ts
+++ b/e2e/helpers/polling.ts
@@ -1,0 +1,27 @@
+export interface PollOptions {
+    timeoutMs?: number;
+    intervalMs?: number;
+    description?: string;
+}
+
+// Repeats an async action until the predicate passes. Use for org-side async
+// processes (Big Object archiving, platform event consumers) where the UI needs
+// to be re-queried, not just re-read.
+export async function pollUntil<T>(
+    action: () => Promise<T>,
+    predicate: (result: T) => boolean,
+    { timeoutMs = 120_000, intervalMs = 5_000, description = 'condition' }: PollOptions = {}
+): Promise<T> {
+    const deadline = Date.now() + timeoutMs;
+    let lastResult: T | undefined;
+    for (;;) {
+        lastResult = await action();
+        if (predicate(lastResult)) {
+            return lastResult;
+        }
+        if (Date.now() > deadline) {
+            throw new Error(`Timed out after ${timeoutMs}ms waiting for ${description}. Last result: ${lastResult}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+}

--- a/e2e/helpers/sf.ts
+++ b/e2e/helpers/sf.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const IS_WINDOWS = process.platform === 'win32';
+
+export const AUTH_DIR = path.join(__dirname, '..', '.auth');
+export const ORG_INFO_PATH = path.join(AUTH_DIR, 'org.json');
+export const STORAGE_STATE_PATH = path.join(AUTH_DIR, 'storageState.json');
+export const REPO_ROOT = path.join(__dirname, '..', '..');
+
+export interface OrgInfo {
+    username: string;
+    instanceUrl: string;
+    adminName: string;
+}
+
+// execFileSync with shell:true does not quote arguments, so quote anything with whitespace.
+function quoteForShell(arg: string): string {
+    return /\s/.test(arg) ? `"${arg}"` : arg;
+}
+
+export function sf(args: string[]): string {
+    // The gulp test-e2e task sets RFLIB_E2E_TARGET_ORG to the entered org alias;
+    // without it the sf CLI default org applies.
+    const targetOrg = process.env.RFLIB_E2E_TARGET_ORG;
+    if (targetOrg) {
+        args = [...args, '--target-org', targetOrg];
+    }
+    // Node >=20 refuses to spawn .cmd shims without a shell (CVE-2024-27980 fix),
+    // so on Windows run through the shell; args contain no user input.
+    return execFileSync(IS_WINDOWS ? 'sf.cmd' : 'sf', IS_WINDOWS ? args.map(quoteForShell) : args, {
+        encoding: 'utf8',
+        shell: IS_WINDOWS,
+        cwd: REPO_ROOT,
+        maxBuffer: 64 * 1024 * 1024
+    });
+}
+
+export function sfJson(args: string[]): any {
+    // Local sf wrappers may print noise (code page changes, spinner output)
+    // before the JSON, so strip ANSI codes and try each line starting with '{'.
+    // eslint-disable-next-line no-control-regex
+    const output = sf([...args, '--json']).replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+    const lines = output.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i].trim().startsWith('{')) {
+            const candidate = lines.slice(i).join('\n');
+            const start = candidate.indexOf('{');
+            const end = candidate.lastIndexOf('}');
+            if (end > start) {
+                try {
+                    return JSON.parse(candidate.substring(start, end + 1));
+                } catch {
+                    // keep scanning; noise line happened to start with '{'
+                }
+            }
+        }
+    }
+    throw new Error(`No parseable JSON in sf output: ${output.substring(0, 500)}`);
+}
+
+export function runApex(file: string): void {
+    const result = sfJson(['apex', 'run', '--file', file]);
+    if (result.status !== 0 || !result.result?.success) {
+        throw new Error(`Apex script ${file} failed: ${JSON.stringify(result.result ?? result)}`);
+    }
+}
+
+export function soql(query: string): any[] {
+    const result = sfJson(['data', 'query', '--query', query]);
+    if (result.status !== 0) {
+        throw new Error(`SOQL query failed: ${JSON.stringify(result)}`);
+    }
+    return result.result.records;
+}
+
+export function saveOrgInfo(info: OrgInfo): void {
+    fs.mkdirSync(AUTH_DIR, { recursive: true });
+    fs.writeFileSync(ORG_INFO_PATH, JSON.stringify(info, null, 4));
+}
+
+export function orgInfo(): OrgInfo {
+    return JSON.parse(fs.readFileSync(ORG_INFO_PATH, 'utf8'));
+}

--- a/e2e/pages/application-events.page.ts
+++ b/e2e/pages/application-events.page.ts
@@ -1,0 +1,48 @@
+import { Locator, Page } from '@playwright/test';
+import { orgInfo } from '../helpers/sf';
+
+// Standard object list view for rflib_Application_Event__c.
+export class ApplicationEventsPage {
+    constructor(readonly page: Page) {}
+
+    // Navigates straight to the "All" list view (the tab defaults to Recently
+    // Viewed, which is empty in a fresh org).
+    async gotoAllListView(): Promise<void> {
+        await this.page.goto(`${orgInfo().instanceUrl}/lightning/o/rflib_Application_Event__c/list?filterName=All`, {
+            waitUntil: 'domcontentloaded'
+        });
+        await this.listViewContainer.waitFor({ state: 'visible', timeout: 60_000 });
+    }
+
+    get listViewContainer(): Locator {
+        return this.page
+            .locator('one-record-home-flexipage2, .forceListViewManager, lst-list-view-manager-header')
+            .first();
+    }
+
+    get rowCountText(): Locator {
+        // "X items • Sorted by..." status text below the list view header
+        return this.page.locator('.countSortedByFilteredBy, lst-list-view-manager-status-info').first();
+    }
+
+    rows(): Locator {
+        return this.page.locator('table[role="grid"] tbody tr');
+    }
+
+    // Filters the list view through its search box; needed because the grid
+    // lazily renders only the first ~20 rows.
+    async searchList(text: string): Promise<void> {
+        const search = this.page.getByPlaceholder('Search this list...').first();
+        await search.fill(text);
+        await search.press('Enter');
+        await this.page.waitForTimeout(2_000);
+    }
+
+    rowWithText(text: string | RegExp): Locator {
+        return this.rows().filter({ hasText: text }).first();
+    }
+
+    get refreshButton(): Locator {
+        return this.page.getByRole('button', { name: 'Refresh', exact: true }).first();
+    }
+}

--- a/e2e/pages/log-monitor.page.ts
+++ b/e2e/pages/log-monitor.page.ts
@@ -1,0 +1,118 @@
+import { expect, Locator, Page } from '@playwright/test';
+import { fillDateTime, formatDateUs, selectMenuItem } from '../helpers/lightning';
+
+export const CONNECTION_MODES = {
+    historicAndNew: 'Historic and New Messages',
+    newMessagesOnly: 'New Messages',
+    disconnected: 'Not Connected',
+    archive: 'Archive'
+} as const;
+
+export class LogMonitorPage {
+    constructor(readonly page: Page) {}
+
+    get root(): Locator {
+        return this.page.locator('c-rflib-log-event-monitor').first();
+    }
+
+    get header(): Locator {
+        return this.root.locator('.slds-page-header').first();
+    }
+
+    get totalLogEventsText(): Locator {
+        return this.header.locator('p').filter({ hasText: 'Total Log Events' });
+    }
+
+    get connectionStatusText(): Locator {
+        return this.header.locator('p').filter({ hasText: 'Connection Status' });
+    }
+
+    get connectionModeMenu(): Locator {
+        // The connection mode menu is the lightning-button-menu with the mode label.
+        return this.header
+            .locator('lightning-button-menu')
+            .filter({
+                hasText: /Historic and New Messages|New Messages|Not Connected|Archive/
+            })
+            .first();
+    }
+
+    // The status label only updates once the EMP (un)subscribe round trip
+    // completes; that can stall, so retry the menu selection a few times.
+    async setConnectionMode(modeLabel: string): Promise<void> {
+        for (let attempt = 1; ; attempt++) {
+            await selectMenuItem(this.connectionModeMenu, modeLabel);
+            try {
+                await expect(this.connectionStatusText).toContainText(modeLabel, { timeout: 20_000 });
+                return;
+            } catch (error) {
+                if (attempt >= 3) {
+                    throw error;
+                }
+                await this.page.keyboard.press('Escape'); // close a possibly stuck menu
+            }
+        }
+    }
+
+    async getTotalLogEvents(): Promise<number> {
+        const text = (await this.totalLogEventsText.textContent()) ?? '0';
+        return parseInt(text.trim().split(' ')[0], 10);
+    }
+
+    get eventList(): Locator {
+        return this.root.locator('c-rflib-log-event-list');
+    }
+
+    eventRows(): Locator {
+        return this.eventList.locator('c-rflib-log-event-list-row');
+    }
+
+    searchField(placeholder: string): Locator {
+        return this.eventList.getByPlaceholder(placeholder);
+    }
+
+    get searchButton(): Locator {
+        return this.eventList.getByRole('button', { name: 'Search' });
+    }
+
+    get viewer(): Locator {
+        return this.root.locator('c-rflib-log-event-viewer');
+    }
+
+    get exportButton(): Locator {
+        return this.header.getByRole('button', { name: 'Export to CSV' });
+    }
+
+    get clearLogsButton(): Locator {
+        return this.header.getByRole('button', { name: 'Clear Logs' });
+    }
+
+    get queryArchiveButton(): Locator {
+        return this.header.getByRole('button', { name: 'Query Archive' });
+    }
+
+    // The archive header renders start date, end date inputs in order.
+    archiveDateInput(index: 0 | 1): Locator {
+        return this.header.locator('li:has(lightning-input) lightning-input').nth(index);
+    }
+
+    async setArchiveDateRange(start: Date, end: Date): Promise<void> {
+        await fillDateTime(this.archiveDateInput(0), formatDateUs(start), '12:00 AM');
+        await fillDateTime(this.archiveDateInput(1), formatDateUs(end), '11:59 PM');
+    }
+
+    // Settings menu in archive mode (contains "Clear Archive"). It precedes the
+    // connection mode menu in the actions button group.
+    get archiveSettingsMenu(): Locator {
+        return this.header.locator('.slds-page-header__col-actions lightning-button-menu').first();
+    }
+
+    // Field visibility menu lives in the second header row's controls area.
+    get fieldVisibilityMenu(): Locator {
+        return this.header.locator('.slds-page-header__col-controls lightning-button-menu').first();
+    }
+
+    get fullscreenToggle(): Locator {
+        return this.header.locator('.slds-page-header__col-controls lightning-button-icon').first();
+    }
+}

--- a/e2e/pages/logger-settings.page.ts
+++ b/e2e/pages/logger-settings.page.ts
@@ -1,0 +1,33 @@
+import { Locator, Page } from '@playwright/test';
+
+export class LoggerSettingsPage {
+    constructor(readonly page: Page) {}
+
+    get root(): Locator {
+        return this.page.locator('c-rflib-custom-settings-editor').first();
+    }
+
+    get refreshButton(): Locator {
+        return this.root.getByRole('button', { name: 'Refresh', exact: true });
+    }
+
+    get newButton(): Locator {
+        return this.root.getByRole('button', { name: 'New', exact: true });
+    }
+
+    get datatable(): Locator {
+        return this.root.locator('lightning-datatable');
+    }
+
+    row(text: string | RegExp): Locator {
+        return this.datatable.locator('tbody tr').filter({ hasText: text }).first();
+    }
+
+    get modal(): Locator {
+        return this.root.locator('section[role="dialog"]');
+    }
+
+    modalField(apiName: string): Locator {
+        return this.modal.locator(`[data-field-name="${apiName}"]`);
+    }
+}

--- a/e2e/pages/management-console.page.ts
+++ b/e2e/pages/management-console.page.ts
@@ -1,0 +1,48 @@
+import { Locator, Page } from '@playwright/test';
+
+export class ManagementConsolePage {
+    constructor(readonly page: Page) {}
+
+    get banner(): Locator {
+        return this.page
+            .locator('.slds-rich-text-editor__output, flexipage-component2')
+            .filter({ hasText: 'RFLIB Wiki' })
+            .first();
+    }
+
+    get archiveAlert(): Locator {
+        return this.page.locator('c-rflib-log-archive-alert div[role="alert"]');
+    }
+
+    get archiveAlertLink(): Locator {
+        return this.archiveAlert.getByRole('link', { name: 'Investigate in the Log Monitor' });
+    }
+
+    permissionAssignmentList(title: string): Locator {
+        return this.page.locator('c-rflib-user-permission-assignment-list').filter({ hasText: title }).first();
+    }
+
+    get publicGroupManager(): Locator {
+        return this.page.locator('c-rflib-public-group-member-manager').first();
+    }
+
+    get permissionSetManager(): Locator {
+        return this.page.locator('c-rflib-user-permission-set-manager').first();
+    }
+
+    orgLimitCard(title: string): Locator {
+        return this.page.locator('c-rflib-org-limit-stat').filter({ hasText: title }).first();
+    }
+
+    get bigObjectStat(): Locator {
+        return this.page.locator('c-rflib-big-object-stat').first();
+    }
+
+    // Job scheduler cards are titled "Job Status for: <jobName>".
+    jobScheduler(jobName: string): Locator {
+        return this.page
+            .locator('c-rflib-apex-job-scheduler')
+            .filter({ hasText: `Job Status for: ${jobName}` })
+            .first();
+    }
+}

--- a/e2e/pages/ops-center-app.page.ts
+++ b/e2e/pages/ops-center-app.page.ts
@@ -1,0 +1,61 @@
+import { expect, Page } from '@playwright/test';
+import { orgInfo } from '../helpers/sf';
+
+export const APP_NAME = 'RFLIB Ops Center';
+
+export const TABS = {
+    managementConsole: 'Management Console',
+    loggerSettings: 'Logger Settings',
+    logMonitor: 'Log Monitor',
+    permissionsExplorer: 'Permissions Explorer',
+    appEventsDashboard: 'Application Events Dashboard',
+    applicationEvents: 'Application Events'
+} as const;
+
+export class OpsCenterApp {
+    constructor(readonly page: Page) {}
+
+    // Opens the app through the App Launcher search. The app may not be on the
+    // shortlist, so always search instead of clicking a shortlisted item.
+    async openViaAppLauncher(): Promise<void> {
+        await this.page.goto(`${orgInfo().instanceUrl}/lightning/page/home`, { waitUntil: 'domcontentloaded' });
+        const waffle = this.page
+            .getByRole('button', { name: 'App Launcher' })
+            .or(this.page.locator('button div.slds-icon-waffle'))
+            .first();
+        await waffle.click();
+        const search = this.page.getByPlaceholder('Search apps and items...').first();
+        await search.waitFor({ state: 'visible' });
+        await search.fill('Ops Center');
+        const appLink = this.page
+            .locator(`one-app-launcher-menu-item a[data-label="${APP_NAME}"], a[data-label="${APP_NAME}"]`)
+            .or(this.page.getByRole('option', { name: APP_NAME }))
+            .first();
+        await appLink.click();
+        await this.expectAppHeader();
+    }
+
+    async expectAppHeader(): Promise<void> {
+        const appName = this.page
+            .locator('.slds-context-bar__label-action span.slds-truncate, .appName span')
+            .filter({ hasText: APP_NAME })
+            .first();
+        await expect(appName).toBeVisible({ timeout: 60_000 });
+    }
+
+    async gotoTab(label: string): Promise<void> {
+        const navLink = this.page
+            .locator(`one-appnav a[title="${label}"]`)
+            .or(this.page.getByRole('navigation').getByRole('link', { name: label, exact: true }))
+            .first();
+        await navLink.click();
+        await this.page.waitForLoadState('domcontentloaded');
+    }
+
+    tabLink(label: string) {
+        return this.page
+            .locator(`one-appnav a[title="${label}"]`)
+            .or(this.page.getByRole('navigation').getByRole('link', { name: label, exact: true }))
+            .first();
+    }
+}

--- a/e2e/pages/permissions-explorer.page.ts
+++ b/e2e/pages/permissions-explorer.page.ts
@@ -1,0 +1,88 @@
+import { expect, Locator, Page } from '@playwright/test';
+import { selectMenuItem, waitForSpinners } from '../helpers/lightning';
+
+export const PERMISSION_TYPES = {
+    objectProfiles: 'Object Permission For Profiles',
+    objectPermissionSets: 'Object Permission for Permission Sets',
+    fieldProfiles: 'Field Permissions for Profiles',
+    apexPermissionSets: 'Apex Permissions for Permission Sets',
+    objectUser: 'Object Permission for a User'
+} as const;
+
+export class PermissionsExplorerPage {
+    constructor(readonly page: Page) {}
+
+    get root(): Locator {
+        return this.page.locator('c-rflib-permissions-explorer').first();
+    }
+
+    get header(): Locator {
+        return this.root.locator('.slds-page-header').first();
+    }
+
+    get totalRecordsTitle(): Locator {
+        return this.header.locator('h1').filter({ hasText: 'Total Permission Records' });
+    }
+
+    get permissionTypeText(): Locator {
+        return this.header.locator('p').filter({ hasText: 'Permission Type' });
+    }
+
+    // Header button group renders three menus in fixed order: permission type,
+    // export, page size.
+    get permissionTypeMenu(): Locator {
+        return this.header.locator('lightning-button-menu').nth(0);
+    }
+
+    get exportMenu(): Locator {
+        return this.header.locator('lightning-button-menu').nth(1);
+    }
+
+    get pageSizeMenu(): Locator {
+        return this.header.locator('lightning-button-menu').nth(2);
+    }
+
+    async selectPermissionType(label: string): Promise<void> {
+        await selectMenuItem(this.permissionTypeMenu, label);
+        await expect(this.permissionTypeText).toContainText(label, { timeout: 30_000 });
+        await this.waitForLoad();
+    }
+
+    async waitForLoad(): Promise<void> {
+        // Loading large orgs pages through records; allow generous time.
+        await waitForSpinners(this.root, 180_000);
+    }
+
+    async getTotalRecords(): Promise<number> {
+        const text = (await this.totalRecordsTitle.textContent()) ?? '0';
+        return parseInt(text.trim().split(' ')[0], 10);
+    }
+
+    get table(): Locator {
+        return this.root.locator('c-rflib-permissions-table');
+    }
+
+    get tableRows(): Locator {
+        return this.table.locator('tbody tr');
+    }
+
+    get userPicker(): Locator {
+        return this.root.locator('lightning-record-picker');
+    }
+
+    get aggregateButton(): Locator {
+        return this.root.getByRole('button', { name: 'Aggregate Permissions' });
+    }
+
+    get resetButton(): Locator {
+        return this.root.getByRole('button', { name: 'Reset Permissions' });
+    }
+
+    get exportFilterModal(): Locator {
+        return this.root.locator('section[role="dialog"]').filter({ hasText: 'Export Filters' });
+    }
+
+    get paginator(): Locator {
+        return this.root.locator('c-rflib-paginator');
+    }
+}

--- a/e2e/specs/01-app-navigation.spec.ts
+++ b/e2e/specs/01-app-navigation.spec.ts
@@ -1,0 +1,66 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { createOpsCenterSession } from '../fixtures';
+import { OpsCenterApp, TABS } from '../pages/ops-center-app.page';
+
+test.describe.configure({ mode: 'serial' });
+
+let context: BrowserContext;
+let page: Page;
+let app: OpsCenterApp;
+
+test.beforeAll(async ({ browser }) => {
+    ({ context, page, app } = await createOpsCenterSession(browser));
+});
+
+test.afterAll(async () => {
+    await context?.close();
+});
+
+test('opens RFLIB Ops Center through the App Launcher search', async () => {
+    // The full App Launcher flow (waffle -> search -> select) ran in beforeAll;
+    // verify it landed in the right app.
+    await app.expectAppHeader();
+    expect(page.url()).toContain('/lightning/');
+});
+
+test('shows all six Ops Center tabs', async () => {
+    for (const label of Object.values(TABS)) {
+        await expect(app.tabLink(label)).toBeVisible();
+    }
+});
+
+test('Management Console tab renders the dashboard components', async () => {
+    await app.gotoTab(TABS.managementConsole);
+    await expect(page.locator('c-rflib-org-limit-stat').first()).toBeVisible({ timeout: 60_000 });
+    await expect(page.locator('c-rflib-big-object-stat')).toBeVisible();
+});
+
+test('Logger Settings tab renders the custom settings editor', async () => {
+    await app.gotoTab(TABS.loggerSettings);
+    await expect(page.locator('c-rflib-custom-settings-editor')).toBeVisible({ timeout: 60_000 });
+});
+
+test('Log Monitor tab renders the log event monitor', async () => {
+    await app.gotoTab(TABS.logMonitor);
+    await expect(page.locator('c-rflib-log-event-monitor')).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByText('Total Log Events')).toBeVisible();
+});
+
+test('Permissions Explorer tab renders the permissions explorer', async () => {
+    await app.gotoTab(TABS.permissionsExplorer);
+    await expect(page.locator('c-rflib-permissions-explorer')).toBeVisible({ timeout: 60_000 });
+});
+
+test('Application Events Dashboard tab activates', async () => {
+    await app.gotoTab(TABS.appEventsDashboard);
+    await page.waitForURL(/rflib_Application_Events_Dashboard/, { timeout: 60_000 });
+    await app.expectAppHeader();
+});
+
+test('Application Events tab shows the object list view', async () => {
+    await app.gotoTab(TABS.applicationEvents);
+    await page.waitForURL(/rflib_Application_Event__c/, { timeout: 60_000 });
+    await expect(
+        page.locator('.forceListViewManager, lst-list-view-manager-header, one-record-home-flexipage2').first()
+    ).toBeVisible({ timeout: 60_000 });
+});

--- a/e2e/specs/02-management-console.spec.ts
+++ b/e2e/specs/02-management-console.spec.ts
@@ -1,0 +1,201 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { createOpsCenterSession } from '../fixtures';
+import { clickDialogButton, datatableRow, pickRecord, waitForToastsToClear } from '../helpers/lightning';
+import { pollUntil } from '../helpers/polling';
+import { orgInfo } from '../helpers/sf';
+import { ManagementConsolePage } from '../pages/management-console.page';
+import { OpsCenterApp, TABS } from '../pages/ops-center-app.page';
+
+test.describe.configure({ mode: 'serial' });
+
+const ORG_LIMIT_CARDS = [
+    'Hourly Published Platform Events',
+    'Daily Streaming API Events',
+    'Streaming API Concurrent Clients',
+    'Daily API Requests',
+    'Single Emails',
+    'Mass Emails'
+];
+
+const JOB_SCHEDULERS = [
+    'RFLIB Application Event Archiver',
+    'RFLIB Log Archive Cleanup',
+    'RFLIB Application Event Archive Cleanup'
+];
+
+let context: BrowserContext;
+let page: Page;
+let app: OpsCenterApp;
+let console_: ManagementConsolePage;
+
+test.beforeAll(async ({ browser }) => {
+    ({ context, page, app } = await createOpsCenterSession(browser, TABS.managementConsole));
+    console_ = new ManagementConsolePage(page);
+});
+
+test.afterAll(async () => {
+    await context?.close();
+});
+
+test('shows the info banner with documentation links', async () => {
+    await expect(console_.banner).toBeVisible({ timeout: 60_000 });
+    await expect(console_.banner.getByRole('link', { name: 'RFLIB Wiki' })).toBeVisible();
+    await expect(console_.banner.getByRole('link', { name: 'RFLIB SFDX Plugin' })).toBeVisible();
+    await expect(console_.banner.getByRole('link', { name: 'Issue on Github' })).toBeVisible();
+});
+
+test('org limit cards show usage values and can refresh', async () => {
+    for (const title of ORG_LIMIT_CARDS) {
+        const card = console_.orgLimitCard(title);
+        await expect(card).toBeVisible({ timeout: 60_000 });
+        await expect(card).toContainText(/Using \d+ out of \d+/, { timeout: 60_000 });
+    }
+    const firstCard = console_.orgLimitCard(ORG_LIMIT_CARDS[0]);
+    await firstCard.getByRole('button', { name: 'Refresh' }).click();
+    await expect(firstCard).toContainText(/Using \d+ out of \d+/, { timeout: 60_000 });
+});
+
+test('lists users with Ops Center access and users without client logging', async () => {
+    const opsCenterList = console_.permissionAssignmentList('User Who Do Have Ops Center Access');
+    await expect(opsCenterList).toBeVisible({ timeout: 60_000 });
+    await expect(datatableRow(opsCenterList, orgInfo().adminName)).toBeVisible({ timeout: 60_000 });
+
+    const noLoggingList = console_.permissionAssignmentList('Users Who Do Not Have Client Logging Enabled');
+    await expect(noLoggingList).toBeVisible();
+    await expect(noLoggingList.locator('lightning-datatable')).toBeVisible();
+});
+
+test('Big Object statistics can count all big objects', async () => {
+    test.setTimeout(420_000);
+    const stat = console_.bigObjectStat;
+    await expect(stat).toBeVisible({ timeout: 60_000 });
+    await stat.getByRole('button', { name: 'Count All' }).click();
+
+    // Counting runs async batch jobs; reload until the stats table shows rows.
+    // The wire needs a moment to render after each reload before counting.
+    await pollUntil(
+        async () => {
+            await page.reload({ waitUntil: 'domcontentloaded' });
+            await expect(console_.bigObjectStat).toBeVisible({ timeout: 60_000 });
+            await page.waitForTimeout(5_000);
+            return console_.bigObjectStat.locator('lightning-datatable tbody tr').count();
+        },
+        (count) => count > 0,
+        { timeoutMs: 300_000, intervalMs: 5_000, description: 'big object statistics rows' }
+    );
+});
+
+test('public group manager adds and removes a member', async () => {
+    const manager = console_.publicGroupManager;
+    await expect(manager).toBeVisible({ timeout: 60_000 });
+    const adminName = orgInfo().adminName;
+
+    // Re-runnability: remove the admin first if a previous run left it behind.
+    const existingRow = datatableRow(manager, adminName);
+    if (await existingRow.isVisible()) {
+        await removeGroupMember(existingRow);
+    }
+
+    await pickRecord(manager.locator('lightning-record-picker'), adminName);
+    await manager.getByRole('button', { name: 'Add User' }).click();
+    await expect(datatableRow(manager, adminName)).toBeVisible({ timeout: 60_000 });
+    await waitForToastsToClear(page);
+
+    await removeGroupMember(datatableRow(manager, adminName));
+    await expect(datatableRow(manager, adminName)).toBeHidden({ timeout: 60_000 });
+});
+
+async function removeGroupMember(row: ReturnType<typeof datatableRow>): Promise<void> {
+    const menuButton = row
+        .getByRole('button', { name: /show actions/i })
+        .or(row.locator('lightning-primitive-cell-actions button'))
+        .first();
+    await menuButton.click();
+    await page.getByRole('menuitem', { name: 'Remove' }).first().click();
+    await clickDialogButton(page, 'Remove');
+    await waitForToastsToClear(page);
+}
+
+test('permission set manager assigns and removes a permission set for autoproc', async () => {
+    const manager = console_.permissionSetManager;
+    await expect(manager).toBeVisible({ timeout: 60_000 });
+    // The datatable shows Label and Name in separate cells; the combobox shows
+    // "Label (Name)". Use the RFLIB permission set intended for autoproc -
+    // others (e.g. Ops Center Access) grant ApiEnabled, which the Automated
+    // Process user license rejects.
+    const permSetName = 'rflib_Archive_Application_Events';
+
+    // Cover both delete and assign while restoring the initial assignment
+    // state (the assignment may be intentional org setup).
+    const initiallyAssigned = await datatableRow(manager, permSetName).isVisible();
+    if (initiallyAssigned) {
+        // Delete is a bare button-icon on the row, which opens the confirm modal.
+        await datatableRow(manager, permSetName).getByRole('button', { name: 'Delete' }).first().click();
+        await clickDialogButton(page, 'Delete');
+        await expect(datatableRow(manager, permSetName)).toBeHidden({ timeout: 60_000 });
+        await waitForToastsToClear(page);
+    }
+
+    const combobox = manager.locator('lightning-combobox');
+    await combobox.locator('button, input').first().click();
+    await combobox.getByRole('option', { name: permSetName }).first().click();
+
+    await manager.getByRole('button', { name: 'Assign', exact: true }).click();
+    await clickDialogButton(page, 'Assign');
+    const newRow = datatableRow(manager, permSetName);
+    await expect(newRow).toBeVisible({ timeout: 60_000 });
+    await waitForToastsToClear(page);
+
+    if (!initiallyAssigned) {
+        await newRow.getByRole('button', { name: 'Delete' }).first().click();
+        await clickDialogButton(page, 'Delete');
+        await expect(datatableRow(manager, permSetName)).toBeHidden({ timeout: 60_000 });
+    }
+});
+
+test('apex job schedulers can schedule, refresh, and delete jobs', async () => {
+    for (const jobName of JOB_SCHEDULERS) {
+        const card = console_.jobScheduler(jobName);
+        await expect(card).toBeVisible({ timeout: 60_000 });
+
+        const isScheduled = await card.getByText('Next Run:').isVisible();
+        if (isScheduled) {
+            // Pre-existing schedule (e.g. created by org setup) - verify status only.
+            await expect(card.getByText('Status:')).toBeVisible();
+            await card.getByRole('button', { name: 'Refresh' }).click();
+            await expect(card.getByText('Next Run:')).toBeVisible({ timeout: 60_000 });
+            continue;
+        }
+
+        await expect(card.getByText('No job is currently scheduled')).toBeVisible();
+        await card.locator('lightning-input input').fill('0 0 3 * * ?');
+        await card.getByRole('button', { name: 'Schedule Job' }).click();
+        await expect(card.getByText('Next Run:')).toBeVisible({ timeout: 60_000 });
+        await waitForToastsToClear(page);
+
+        await card.getByRole('button', { name: 'Delete Job' }).click();
+        await clickDialogButton(page, 'Delete');
+        await expect(card.getByText('No job is currently scheduled')).toBeVisible({ timeout: 60_000 });
+        await waitForToastsToClear(page);
+    }
+});
+
+test('log archive alert appears for recent high-severity logs and links to the Log Monitor', async () => {
+    test.setTimeout(420_000);
+    // Archive rows are written asynchronously after global setup published the
+    // seeded WARN/ERROR/FATAL events; reload until the alert renders.
+    await pollUntil(
+        async () => {
+            await page.reload({ waitUntil: 'domcontentloaded' });
+            await expect(console_.banner).toBeVisible({ timeout: 60_000 });
+            await page.waitForTimeout(5_000);
+            return console_.archiveAlert.isVisible();
+        },
+        (visible) => visible,
+        { timeoutMs: 300_000, intervalMs: 5_000, description: 'log archive alert banner' }
+    );
+
+    await console_.archiveAlertLink.click();
+    await expect(page.locator('c-rflib-log-event-monitor')).toBeVisible({ timeout: 60_000 });
+    await app.gotoTab(TABS.managementConsole);
+});

--- a/e2e/specs/03-logger-settings.spec.ts
+++ b/e2e/specs/03-logger-settings.spec.ts
@@ -1,0 +1,87 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { createOpsCenterSession } from '../fixtures';
+import { clickDialogButton, clickRowAction, pickRecord, waitForToastsToClear } from '../helpers/lightning';
+import { orgInfo } from '../helpers/sf';
+import { LoggerSettingsPage } from '../pages/logger-settings.page';
+import { TABS } from '../pages/ops-center-app.page';
+
+test.describe.configure({ mode: 'serial' });
+
+let context: BrowserContext;
+let page: Page;
+let settings: LoggerSettingsPage;
+
+test.beforeAll(async ({ browser }) => {
+    ({ context, page } = await createOpsCenterSession(browser, TABS.loggerSettings));
+    settings = new LoggerSettingsPage(page);
+});
+
+test.afterAll(async () => {
+    await context?.close();
+});
+
+test('shows the org default settings configured by the setup script', async () => {
+    const orgRow = settings.row('Organization');
+    await expect(orgRow).toBeVisible({ timeout: 60_000 });
+    // ConfigureCustomSettings.apex sets Log_Event_Reporting_Level__c and
+    // Archive_Log_Level__c to INFO on the org defaults.
+    await expect(orgRow).toContainText('INFO');
+});
+
+test('creates a new user-level logger setting', async () => {
+    const adminName = orgInfo().adminName;
+
+    // Re-runnability: delete a leftover row from a previous run.
+    const leftoverRow = settings.row(adminName);
+    if (await leftoverRow.isVisible()) {
+        await clickRowAction(leftoverRow, 'Delete');
+        await clickDialogButton(page, 'Delete');
+        await expect(settings.row(adminName)).toBeHidden({ timeout: 60_000 });
+        await waitForToastsToClear(page);
+    }
+
+    await settings.newButton.click();
+    await expect(settings.modal).toBeVisible();
+
+    const typeSelector = settings.modal.locator('lightning-combobox');
+    await typeSelector.locator('button, input').first().click();
+    await typeSelector.getByRole('option', { name: 'User', exact: true }).click();
+
+    await pickRecord(settings.modal.locator('lightning-record-picker'), adminName);
+
+    await settings.modalField('General_Log_Level__c').fill('DEBUG');
+    await settings.modalField('Client_Console_Log_Level__c').fill('TRACE');
+
+    await settings.modal.getByRole('button', { name: 'Save' }).click();
+    const newRow = settings.row(adminName);
+    await expect(newRow).toBeVisible({ timeout: 60_000 });
+    await expect(newRow).toContainText('DEBUG');
+    await waitForToastsToClear(page);
+});
+
+test('edits the user-level setting through the row action', async () => {
+    const row = settings.row(orgInfo().adminName);
+    await clickRowAction(row, 'Edit');
+    await expect(settings.modal).toBeVisible();
+
+    await settings.modalField('General_Log_Level__c').fill('WARN');
+    await settings.modal.getByRole('button', { name: 'Save' }).click();
+
+    await expect(settings.row(orgInfo().adminName)).toContainText('WARN', { timeout: 60_000 });
+    await waitForToastsToClear(page);
+});
+
+test('refresh reloads the settings table', async () => {
+    await settings.refreshButton.click();
+    await expect(settings.row('Organization')).toBeVisible({ timeout: 60_000 });
+    await expect(settings.row(orgInfo().adminName)).toBeVisible({ timeout: 60_000 });
+});
+
+test('deletes the user-level setting with confirmation', async () => {
+    const adminName = orgInfo().adminName;
+    await clickRowAction(settings.row(adminName), 'Delete');
+    await clickDialogButton(page, 'Delete');
+    await expect(settings.row(adminName)).toBeHidden({ timeout: 60_000 });
+    // The org default row must never be deleted by the test.
+    await expect(settings.row('Organization')).toBeVisible();
+});

--- a/e2e/specs/04-log-monitor.spec.ts
+++ b/e2e/specs/04-log-monitor.spec.ts
@@ -1,0 +1,147 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { createOpsCenterSession } from '../fixtures';
+import { runApex } from '../helpers/sf';
+import { CONNECTION_MODES, LogMonitorPage } from '../pages/log-monitor.page';
+import { TABS } from '../pages/ops-center-app.page';
+
+test.describe.configure({ mode: 'serial' });
+
+let context: BrowserContext;
+let page: Page;
+let monitor: LogMonitorPage;
+
+test.beforeAll(async ({ browser }) => {
+    ({ context, page } = await createOpsCenterSession(browser, TABS.logMonitor));
+    monitor = new LogMonitorPage(page);
+});
+
+test.afterAll(async () => {
+    await context?.close();
+});
+
+test('starts in "New Messages" connection mode', async () => {
+    await expect(monitor.root).toBeVisible({ timeout: 60_000 });
+    await expect(monitor.connectionStatusText).toContainText(CONNECTION_MODES.newMessagesOnly);
+    await expect(monitor.totalLogEventsText).toBeVisible();
+});
+
+test('historic mode replays the seeded log events', async () => {
+    await monitor.setConnectionMode(CONNECTION_MODES.historicAndNew);
+    await expect.poll(() => monitor.getTotalLogEvents(), { timeout: 120_000, intervals: [5_000] }).toBeGreaterThan(0);
+    await expect(monitor.eventRows().first()).toBeVisible();
+});
+
+test('receives new log events in real time over the EMP API', async () => {
+    // Reload for a fresh default "New Messages" subscription instead of
+    // toggling modes, which occasionally stalls the EMP resubscribe.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(monitor.connectionStatusText).toContainText(CONNECTION_MODES.newMessagesOnly, { timeout: 60_000 });
+    const baseline = await monitor.getTotalLogEvents();
+
+    runApex('scripts/apex/CreateLogEvent.apex');
+
+    await expect
+        .poll(() => monitor.getTotalLogEvents(), { timeout: 120_000, intervals: [5_000] })
+        .toBeGreaterThan(baseline);
+    await expect(monitor.eventRows().filter({ hasText: 'TestContext' }).first()).toBeVisible();
+});
+
+test('filters log events by level and context', async () => {
+    // Reconnect in historic mode so there is a stable set of rows to filter.
+    await monitor.setConnectionMode(CONNECTION_MODES.historicAndNew);
+    await expect.poll(() => monitor.getTotalLogEvents(), { timeout: 120_000, intervals: [5_000] }).toBeGreaterThan(0);
+
+    await monitor.searchField('Level...').fill('FATAL');
+    await monitor.searchButton.click();
+    await expect(monitor.eventRows().first()).toBeVisible({ timeout: 30_000 });
+    await expect(monitor.eventRows().filter({ hasText: 'DEBUG' })).toHaveCount(0);
+
+    await monitor.searchField('Level...').fill('');
+    await monitor.searchField('Context...').fill('TestContext');
+    await monitor.searchButton.click();
+    await expect(monitor.eventRows().first()).toBeVisible({ timeout: 30_000 });
+    await expect(monitor.eventRows().filter({ hasText: 'TestContext' }).first()).toBeVisible();
+
+    await monitor.searchField('Context...').fill('');
+    await monitor.searchButton.click();
+});
+
+test('paginates when more than one page of events exists', async () => {
+    // Two CreateLogEvent runs (global setup + real-time test) provide >10 events
+    // in replay; top up once more if the org delivered fewer.
+    let total = await monitor.getTotalLogEvents();
+    if (total <= 10) {
+        runApex('scripts/apex/CreateLogEvent.apex');
+        await expect
+            .poll(() => monitor.getTotalLogEvents(), { timeout: 120_000, intervals: [5_000] })
+            .toBeGreaterThan(10);
+        total = await monitor.getTotalLogEvents();
+    }
+    expect(total).toBeGreaterThan(10);
+
+    const footer = monitor.eventList.locator('p').filter({ hasText: 'Page' });
+    await expect(footer).toContainText('Page 1');
+    await monitor.root.locator('c-rflib-paginator').getByRole('button', { name: 'Next' }).click();
+    await expect(footer).toContainText('Page 2');
+    await monitor.root.locator('c-rflib-paginator').getByRole('button', { name: 'First' }).click();
+    await expect(footer).toContainText('Page 1');
+});
+
+test('selecting an event opens the viewer with details, platform info, and stacktrace', async () => {
+    await expect(monitor.viewer).toBeHidden();
+    await monitor.eventRows().first().click();
+    await expect(monitor.viewer).toBeVisible({ timeout: 30_000 });
+
+    await expect(monitor.viewer.getByText('Log Messages')).toBeVisible();
+    await monitor.viewer.getByRole('tab', { name: 'Platform Info' }).click();
+    await expect(monitor.viewer.locator('table').first()).toBeVisible();
+    await monitor.viewer.getByRole('tab', { name: 'Stacktrace' }).click();
+    await expect(monitor.viewer.locator('pre').first()).toBeVisible();
+    await monitor.viewer.getByRole('tab', { name: 'Log Event' }).click();
+
+    // Download menu offers the RFLIB log file entry.
+    await monitor.viewer.locator('lightning-button-menu button').first().click();
+    await expect(page.getByRole('menuitem', { name: 'RFLIB Log File' })).toBeVisible();
+    await page.keyboard.press('Escape');
+});
+
+test('field visibility settings toggle', async () => {
+    const menu = monitor.fieldVisibilityMenu;
+    await menu.click();
+    const requestIdItem = page
+        .getByRole('menuitemcheckbox', { name: 'Show Request ID' })
+        .or(page.getByRole('menuitem', { name: 'Show Request ID' }))
+        .first();
+    await expect(requestIdItem).toBeVisible();
+    await requestIdItem.click();
+
+    // Re-open and toggle back.
+    await menu.click();
+    await page
+        .getByRole('menuitemcheckbox', { name: 'Show Request ID' })
+        .or(page.getByRole('menuitem', { name: 'Show Request ID' }))
+        .first()
+        .click();
+});
+
+test('fullscreen toggle hides and restores the event list', async () => {
+    // The toggle is only enabled when an event is selected (done in prior test).
+    await expect(monitor.eventList).toBeVisible();
+    await monitor.fullscreenToggle.click();
+    await expect(monitor.eventList).toBeHidden();
+    await monitor.fullscreenToggle.click();
+    await expect(monitor.eventList).toBeVisible();
+});
+
+test('exports captured events to CSV', async () => {
+    const downloadPromise = page.waitForEvent('download', { timeout: 60_000 });
+    await monitor.exportButton.click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.csv$/i);
+});
+
+test('clear logs empties the captured event list', async () => {
+    await monitor.clearLogsButton.click();
+    await expect(monitor.totalLogEventsText).toContainText('0 Total Log Events', { timeout: 30_000 });
+    await expect(monitor.eventRows()).toHaveCount(0);
+});

--- a/e2e/specs/05-log-archive.spec.ts
+++ b/e2e/specs/05-log-archive.spec.ts
@@ -1,0 +1,71 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { createOpsCenterSession } from '../fixtures';
+import { clickDialogButton, expectToast, selectMenuItem } from '../helpers/lightning';
+import { pollUntil } from '../helpers/polling';
+import { CONNECTION_MODES, LogMonitorPage } from '../pages/log-monitor.page';
+import { TABS } from '../pages/ops-center-app.page';
+
+// Destructive spec: "Clear Archive" wipes rflib_Logs_Archive__b. It must run
+// after 02 (archive alert, big object counts) and 04 (log monitor).
+test.describe.configure({ mode: 'serial' });
+
+let context: BrowserContext;
+let page: Page;
+let monitor: LogMonitorPage;
+
+test.beforeAll(async ({ browser }) => {
+    ({ context, page } = await createOpsCenterSession(browser, TABS.logMonitor));
+    monitor = new LogMonitorPage(page);
+});
+
+test.afterAll(async () => {
+    await context?.close();
+});
+
+async function queryArchiveAndCountRows(): Promise<number> {
+    await monitor.queryArchiveButton.click();
+    await page.waitForTimeout(3_000);
+    return monitor.eventRows().count();
+}
+
+test('archive mode queries the seeded archived log events', async () => {
+    await monitor.setConnectionMode(CONNECTION_MODES.archive);
+    await expect(monitor.queryArchiveButton).toBeVisible();
+
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    await monitor.setArchiveDateRange(yesterday, tomorrow);
+
+    // Big Object writes are asynchronous; the seeded events from global setup
+    // have had the runtime of specs 01-04 to land. Re-query until rows appear.
+    await pollUntil(queryArchiveAndCountRows, (count) => count > 0, {
+        timeoutMs: 240_000,
+        intervalMs: 10_000,
+        description: 'archived log events'
+    });
+    await expect(monitor.eventRows().filter({ hasText: 'TestContext' }).first()).toBeVisible();
+});
+
+test('archived events open in the log event viewer', async () => {
+    await monitor.eventRows().first().click();
+    await expect(monitor.viewer).toBeVisible({ timeout: 30_000 });
+    await expect(monitor.viewer.getByText('Log Messages')).toBeVisible();
+});
+
+test('clear archive removes expired records after confirmation', async () => {
+    await selectMenuItem(monitor.archiveSettingsMenu, 'Clear Archive');
+    await expect(page.getByText('Are you sure you want to clear the archive?')).toBeVisible();
+    await clickDialogButton(page, 'Clear');
+
+    // Clearing resets the displayed list immediately and reports the count of
+    // deleted records via toast. Only records older than the configured
+    // retention period are deleted, so the fresh test records survive.
+    await expectToast(page, /Cleared \d+ archived records/);
+    await expect(monitor.totalLogEventsText).toContainText('0 Total Log Events');
+
+    await pollUntil(queryArchiveAndCountRows, (count) => count > 0, {
+        timeoutMs: 120_000,
+        intervalMs: 10_000,
+        description: 'recent records to remain after clearing expired ones'
+    });
+});

--- a/e2e/specs/06-permissions-explorer.spec.ts
+++ b/e2e/specs/06-permissions-explorer.spec.ts
@@ -1,0 +1,121 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { createOpsCenterSession } from '../fixtures';
+import { pickRecord, selectMenuItem } from '../helpers/lightning';
+import { orgInfo } from '../helpers/sf';
+import { TABS } from '../pages/ops-center-app.page';
+import { PERMISSION_TYPES, PermissionsExplorerPage } from '../pages/permissions-explorer.page';
+
+test.describe.configure({ mode: 'serial' });
+
+let context: BrowserContext;
+let page: Page;
+let explorer: PermissionsExplorerPage;
+
+test.beforeAll(async ({ browser }) => {
+    ({ context, page } = await createOpsCenterSession(browser, TABS.permissionsExplorer));
+    explorer = new PermissionsExplorerPage(page);
+});
+
+test.afterAll(async () => {
+    await context?.close();
+});
+
+test('loads object permissions for profiles by default', async () => {
+    await expect(explorer.root).toBeVisible({ timeout: 60_000 });
+    await expect(explorer.permissionTypeText).toContainText(PERMISSION_TYPES.objectProfiles);
+    await explorer.waitForLoad();
+    await expect.poll(() => explorer.getTotalRecords(), { timeout: 120_000 }).toBeGreaterThan(0);
+    await expect(explorer.tableRows.first()).toBeVisible();
+});
+
+test('switches between permission types', async () => {
+    for (const type of [
+        PERMISSION_TYPES.objectPermissionSets,
+        PERMISSION_TYPES.fieldProfiles,
+        PERMISSION_TYPES.apexPermissionSets
+    ]) {
+        await explorer.selectPermissionType(type);
+        await expect.poll(() => explorer.getTotalRecords(), { timeout: 180_000 }).toBeGreaterThan(0);
+        await expect(explorer.tableRows.first()).toBeVisible();
+    }
+});
+
+test('user mode aggregates and resets permissions', async () => {
+    await explorer.selectPermissionType(PERMISSION_TYPES.objectUser);
+    await expect(explorer.userPicker).toBeVisible();
+
+    await pickRecord(explorer.userPicker, orgInfo().adminName);
+    await expect(explorer.aggregateButton).toBeEnabled();
+    await explorer.aggregateButton.click();
+    await explorer.waitForLoad();
+    await expect.poll(() => explorer.getTotalRecords(), { timeout: 180_000 }).toBeGreaterThan(0);
+
+    await explorer.resetButton.click();
+    await explorer.waitForLoad();
+    await expect(explorer.aggregateButton).toBeVisible({ timeout: 60_000 });
+});
+
+test('search filters the permissions table', async () => {
+    await explorer.selectPermissionType(PERMISSION_TYPES.objectProfiles);
+    await expect.poll(() => explorer.getTotalRecords(), { timeout: 180_000 }).toBeGreaterThan(0);
+
+    const searchInput = explorer.table.getByPlaceholder('Search Object/Class/Page...');
+    await searchInput.fill('Account');
+    await searchInput.press('Enter');
+    await expect(explorer.tableRows.first()).toBeVisible({ timeout: 30_000 });
+    await expect(explorer.tableRows.first()).toContainText('Account');
+
+    await searchInput.fill('');
+    await searchInput.press('Enter');
+});
+
+test('page size selection shows more rows per page', async () => {
+    const rowsAtTen = await explorer.tableRows.count();
+    expect(rowsAtTen).toBeLessThanOrEqual(10);
+
+    await selectMenuItem(explorer.pageSizeMenu, '50');
+    await expect.poll(() => explorer.tableRows.count(), { timeout: 60_000 }).toBeGreaterThan(10);
+
+    await selectMenuItem(explorer.pageSizeMenu, '10');
+    await expect.poll(() => explorer.tableRows.count(), { timeout: 60_000 }).toBeLessThanOrEqual(10);
+});
+
+test('paginator navigates pages including go-to-page', async () => {
+    const pageInput = explorer.paginator.locator('input');
+    await expect(pageInput).toHaveValue('1');
+
+    await explorer.paginator.getByRole('button', { name: 'Next' }).click();
+    await expect(pageInput).toHaveValue('2');
+
+    await explorer.paginator.getByRole('button', { name: 'Last' }).click();
+    const lastPage = await pageInput.inputValue();
+    expect(parseInt(lastPage, 10)).toBeGreaterThan(1);
+
+    await pageInput.fill('1');
+    await pageInput.press('Enter');
+    await expect(pageInput).toHaveValue('1');
+});
+
+test('exports all permissions to CSV', async () => {
+    const downloadPromise = page.waitForEvent('download', { timeout: 120_000 });
+    await selectMenuItem(explorer.exportMenu, 'All');
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.csv$/i);
+});
+
+test('exports filtered permissions through the filter modal with help text', async () => {
+    await selectMenuItem(explorer.exportMenu, 'Filtered');
+    const modal = explorer.exportFilterModal;
+    await expect(modal).toBeVisible();
+
+    // Collapsible help section explains the filter logic.
+    await modal.getByText('Click to learn how filtering works').click();
+    await expect(modal.getByText('Values within the same field are combined with OR logic')).toBeVisible();
+
+    await modal.getByPlaceholder('Enter comma-separated names...').nth(1).fill('Account');
+    const downloadPromise = page.waitForEvent('download', { timeout: 120_000 });
+    await modal.getByRole('button', { name: 'Export', exact: true }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.csv$/i);
+    await expect(modal).toBeHidden({ timeout: 30_000 });
+});

--- a/e2e/specs/07-application-events.spec.ts
+++ b/e2e/specs/07-application-events.spec.ts
@@ -1,0 +1,68 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { createOpsCenterSession } from '../fixtures';
+import { pollUntil } from '../helpers/polling';
+import { runApex } from '../helpers/sf';
+import { ApplicationEventsPage } from '../pages/application-events.page';
+import { TABS } from '../pages/ops-center-app.page';
+
+test.describe.configure({ mode: 'serial' });
+
+let context: BrowserContext;
+let page: Page;
+let events: ApplicationEventsPage;
+
+test.beforeAll(async ({ browser }) => {
+    ({ context, page } = await createOpsCenterSession(browser, TABS.applicationEvents));
+    events = new ApplicationEventsPage(page);
+});
+
+test.afterAll(async () => {
+    await context?.close();
+});
+
+test('the All list view shows the seeded application events', async () => {
+    await events.gotoAllListView();
+    await expect(events.rows().first()).toBeVisible({ timeout: 60_000 });
+
+    // The grid lazily renders only the first ~20 rows, so verify each seeded
+    // event name through the list search box instead of scanning rows.
+    for (const eventName of ['bot-request-success', 'import-sample-data']) {
+        await events.searchList(eventName);
+        await expect(events.rowWithText(eventName)).toBeVisible({ timeout: 30_000 });
+    }
+});
+
+test('platform events create application event records asynchronously', async () => {
+    test.setTimeout(480_000);
+    runApex('scripts/apex/CreateApplicationEventOccurredEvent.apex');
+
+    // The platform event flow runs asynchronously and queue processing in
+    // scratch orgs can lag by several minutes. The list view only renders the
+    // first ~20 rows, so filter via the list search box instead of scrolling.
+    await pollUntil(
+        async () => {
+            await events.gotoAllListView();
+            await events.searchList('Test Event');
+            return events.rowWithText('Today Test Event').isVisible();
+        },
+        (visible) => visible,
+        { timeoutMs: 420_000, intervalMs: 10_000, description: 'application event from platform event' }
+    );
+    await expect(events.rowWithText('Yesterday Test Event')).toBeVisible();
+});
+
+test('delete-all script empties the application events list', async () => {
+    runApex('scripts/apex/DeleteAllApplicationEvents.apex');
+
+    await pollUntil(
+        async () => {
+            await events.gotoAllListView();
+            return events.rows().count();
+        },
+        (count) => count === 0,
+        { timeoutMs: 120_000, intervalMs: 10_000, description: 'empty application events list' }
+    );
+
+    // Restore seed data so a re-run of the suite still finds records.
+    runApex('scripts/apex/CreateApplicationEvent.apex');
+});

--- a/e2e/specs/08-app-events-dashboard.spec.ts
+++ b/e2e/specs/08-app-events-dashboard.spec.ts
@@ -1,0 +1,35 @@
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { createOpsCenterSession } from '../fixtures';
+import { OpsCenterApp, TABS } from '../pages/ops-center-app.page';
+
+test.describe.configure({ mode: 'serial' });
+
+let context: BrowserContext;
+let page: Page;
+let app: OpsCenterApp;
+
+test.beforeAll(async ({ browser }) => {
+    ({ context, page, app } = await createOpsCenterSession(browser));
+});
+
+test.afterAll(async () => {
+    await context?.close();
+});
+
+test('the Application Events Dashboard tab activates without breaking the app', async () => {
+    await app.gotoTab(TABS.appEventsDashboard);
+    await page.waitForURL(/rflib_Application_Events_Dashboard/, { timeout: 60_000 });
+
+    // The flexipage embeds an analytics dashboard with a hardcoded ID that does
+    // not exist in a scratch org, so assert only that the page shell renders:
+    // the tab heading and the embedded dashboard's iframe container.
+    await expect(page.getByRole('heading', { name: 'Application Events Dashboard' })).toBeVisible({
+        timeout: 90_000
+    });
+    await expect(page.locator('iframe').first()).toBeAttached({ timeout: 90_000 });
+    await app.expectAppHeader();
+
+    // Navigation away still works after visiting the dashboard tab.
+    await app.gotoTab(TABS.managementConsole);
+    await expect(page.locator('c-rflib-org-limit-stat').first()).toBeVisible({ timeout: 60_000 });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "CommonJS",
+        "moduleResolution": "node",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "types": ["node"]
+    },
+    "include": ["**/*.ts", "../playwright.config.ts"]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -643,6 +643,13 @@ gulp.task(
     })
 );
 
+gulp.task('shell-test-e2e', function (done) {
+    const headed = process.argv.includes('--chrome');
+    return shell.task(`npx playwright test${headed ? ' --headed' : ''}`, {
+        env: { RFLIB_E2E_TARGET_ORG: config.alias }
+    })(done);
+});
+
 gulp.task('shell-force-test-package-install-and-upgrade',
     shellTask(function () {
         const skipBaseInstall = process.argv.includes('--skip-base-install');
@@ -855,6 +862,11 @@ gulp.task(
         'shell-test-lwc'
     )
 );
+
+// End-to-end UI test task. Prompts for the org alias (or accepts --alias <name>)
+// and runs the Playwright suite against that org. Pass --chrome to watch the
+// tests run in a visible Chrome window; the default is headless.
+gulp.task('test-e2e', gulp.series('prompt-alias', 'shell-test-e2e'));
 
 // Create event task
 gulp.task('create-event', gulp.series('prompt-alias', 'shell-force-create-log-event'));

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,8 @@ setupFilesAfterEnv.push('<rootDir>/jest-sa11y-setup.js');
 const newConfig = {
     ...jestConfig,
     setupFilesAfterEnv: ['./jest.setup.js'],
+    // Playwright E2E specs are run by "npm run test:e2e", not Jest
+    testPathIgnorePatterns: [...(jestConfig.testPathIgnorePatterns || []), '<rootDir>/e2e/'],
     moduleNameMapper: {
         '^@salesforce/apex$': '<rootDir>/rflib/test/jest-mocks/apex',
         '^lightning/navigation$': '<rootDir>/rflib/test/jest-mocks/lightning/navigation',

--- a/package.json
+++ b/package.json
@@ -43,10 +43,12 @@
         "@babel/eslint-parser": "^7.29.7",
         "@eslint/js": "^9.39.1",
         "@lwc/eslint-plugin-lwc": "^3.5.0",
+        "@playwright/test": "^1.60.0",
         "@salesforce/eslint-config-lwc": "^4.1.2",
         "@salesforce/eslint-plugin-aura": "^3.0.0",
         "@salesforce/eslint-plugin-lightning": "^2.0.0",
         "@salesforce/sfdx-lwc-jest": "^7.1.2",
+        "@types/node": "^25.9.3",
         "ai-digest": "^1.5.1",
         "codecov": "^3.8.3",
         "cspell": "^10.0.0",
@@ -74,7 +76,7 @@
         "time-require": "^0.1.2"
     },
     "lint-staged": {
-        "**/*.{html,js,json,yaml,yml,md,cmp,page,component}": [
+        "**/*.{html,js,ts,json,yaml,yml,md,cmp,page,component}": [
             "prettier --write"
         ],
         "**/lwc/**": [
@@ -94,8 +96,12 @@
         "test:unit:watch": "sfdx-lwc-jest --watch",
         "test:unit:debug": "sfdx-lwc-jest --debug",
         "test:unit:coverage": "sfdx-lwc-jest --coverage",
-        "prettier": "prettier --write '**/*.{cmp,component,css,html,js,cjs,json,md,page,yaml,yml}'",
-        "prettier:verify": "prettier --list-different '**/*.{html,js,cjs,json,yaml,yml,md,cmp,page,component}'",
+        "test:e2e": "playwright test",
+        "test:e2e:ui": "playwright test --ui",
+        "test:e2e:headed": "playwright test --headed",
+        "test:e2e:report": "playwright show-report",
+        "prettier": "prettier --write '**/*.{cmp,component,css,html,js,cjs,ts,json,md,page,yaml,yml}'",
+        "prettier:verify": "prettier --list-different '**/*.{html,js,cjs,ts,json,yaml,yml,md,cmp,page,component}'",
         "cspell": "cspell \"**/*.js\" \"**/*.cls\" \"**/*.html\" \"**/*.css\" \"**/*.md\" \"**/*.cjs\" \"**/*.ts\"",
         "prepare": "husky"
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// The instance URL is only known after global setup resolves the default org.
+// baseURL is a convenience; all navigation builds absolute URLs from orgInfo().
+const ORG_INFO_PATH = path.join(__dirname, 'e2e', '.auth', 'org.json');
+const baseURL = fs.existsSync(ORG_INFO_PATH)
+    ? JSON.parse(fs.readFileSync(ORG_INFO_PATH, 'utf8')).instanceUrl
+    : undefined;
+
+export default defineConfig({
+    testDir: './e2e/specs',
+    globalSetup: './e2e/global-setup.ts',
+    // Specs share one scratch org and EMP subscriptions; spec 05 destroys data
+    // that 02/04 depend on, so ordering (numeric prefixes) must be preserved.
+    fullyParallel: false,
+    workers: 1,
+    retries: 1,
+    timeout: 180_000,
+    expect: { timeout: 30_000 },
+    reporter: [['list'], ['html', { open: 'never' }]],
+    use: {
+        baseURL,
+        storageState: path.join(__dirname, 'e2e', '.auth', 'storageState.json'),
+        viewport: { width: 1600, height: 900 },
+        actionTimeout: 30_000,
+        navigationTimeout: 60_000,
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+        video: 'retain-on-failure'
+    },
+    projects: [{ name: 'chromium', use: { browserName: 'chromium' } }]
+});

--- a/scripts/apex/ConfigureCustomSettings.apex
+++ b/scripts/apex/ConfigureCustomSettings.apex
@@ -4,4 +4,9 @@ settings.Log_Event_Reporting_Level__c = 'INFO';
 settings.Archive_Log_Level__c = 'INFO';
 settings.Log_Aggregation_Log_Level__c = 'WARN';
 
+// Required field; records created before the field was introduced may hold null.
+if (settings.Google_Chat_Log_Level__c == null) {
+    settings.Google_Chat_Log_Level__c = 'NONE';
+}
+
 upsert settings;


### PR DESCRIPTION
## What

Adds a complete Playwright end-to-end UI test suite for the RFLIB Ops Center — 46 tests across 8 spec files covering all 6 tabs — plus a `gulp test-e2e` task to run it.

### Test coverage

- **App navigation**: opens the app through the App Launcher search (never assumes it is shortlisted), verifies all tabs render their components.
- **Management Console**: info banner, org limit cards, user permission lists, Big Object "Count All", public group member add/remove, autoproc permission set assign/remove, all three Apex job schedulers (schedule → refresh → delete), log archive alert + link.
- **Logger Settings**: org defaults, create/edit/delete of a user-level setting via the editor modal.
- **Log Monitor**: historic replay, **real-time EMP streaming** (publishes `rflib_Log_Event__e` mid-test via `sf apex run`), search filters, pagination, event viewer tabs, CSV export, field visibility, fullscreen, clear logs.
- **Log Archive**: date-range queries against `rflib_Logs_Archive__b`, viewer, and Clear Archive (asserts the actual retention semantics — only expired records are deleted).
- **Permissions Explorer**: permission type switching, user-mode aggregation/reset, search, page size, paginator go-to-page, CSV export (all + filtered with help modal).
- **Application Events**: seeded list view, async record creation from `rflib_Application_Event_Occurred_Event__e` platform events, delete-all cleanup.
- **Application Events Dashboard**: tab renders without breaking the app shell (the embedded dashboard ID is org-specific).

### Infrastructure

- Auth via `sf org open --url-only` frontdoor URL against the sf CLI default org; session stored as Playwright `storageState` in global setup.
- Data seeding reuses the existing `scripts/apex` scripts; tests publish additional events mid-run for streaming/async assertions.
- `gulp test-e2e` prompts for the org alias (or `--alias <name>`) and passes it to the tests via `RFLIB_E2E_TARGET_ORG`; headless by default, `--chrome` runs headed.
- Serial execution (`workers: 1`, numbered specs) because tests share org data and EMP subscriptions; polling helpers absorb scratch-org async lag (Big Object archiving, platform event consumers).
- npm scripts: `test:e2e`, `test:e2e:ui`, `test:e2e:headed`, `test:e2e:report`.

### Bug fix

`scripts/apex/ConfigureCustomSettings.apex` failed with `REQUIRED_FIELD_MISSING` on orgs whose `rflib_Logger_Settings__c` org-default record predates the required `Google_Chat_Log_Level__c` field; it now defaults the field to `NONE` when null.

## Why

RFLIB had Apex and LWC Jest coverage but no end-to-end UI verification. This suite exercises every Ops Center page against a real scratch org, including the event-driven async paths (EMP streaming, Big Object archiving, platform event consumers) that unit tests cannot reach.

## Notes for reviewers

- Tests were verified green twice in a row against the same scratch org (the suite is idempotent; destructive tests restore state or reseed).
- First run on a fresh org takes ~15–20 min (async archive writes, count jobs); subsequent runs ~5 min.
- Two findings encoded as assertions rather than "fixed": Clear Archive only deletes records past the retention period, and the Automated Process user license rejects permission sets granting `ApiEnabled` (the test uses `rflib_Archive_Application_Events`, the set intended for autoproc).
- New deps: `@playwright/test`, `@types/node` (dev only). Run `npx playwright install chromium` once before first use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
