### PR TITLE
feat(rflib-tf): add Publish After Commit variant of the Retryable Action event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### RFLIB-TF 4.0.0
+
+- Added the `rflib_Retryable_Action_After_Commit__e` Platform Event, a variant of `rflib_Retryable_Action__e` with identical fields but with the `Publish After Commit` behavior. Publish this event instead of the original when handlers depend on the records of the publishing transaction being committed (e.g. record lookups in the subscriber); the original event keeps its `Publish Immediately` behavior, which delivers events even if the publishing transaction rolls back. Both events share the same `rflib_Retryable_Action_Config__mdt` configuration, handler interface, retry behavior, and the `rflib_Disable_All_Retryable_Actions` feature switch.
+- **BREAKING:** `rflib_RetryableActionHandler.execute()` now receives a `List<rflib_RetryableAction>` instead of a `List<rflib_Retryable_Action__e>`. The new read-only `rflib_RetryableAction` data object works for both Platform Events and exposes the custom fields as properties named after the field API names without the `__c` suffix (`Action`, `Record_ID`, `Additional_Record_ID`, `Additional_Details`), the standard event fields (`ReplayId`, `EventUuid`), and the raw event record via the `event` property. To migrate a handler, change the parameter type of `execute()` and drop the `__c` suffix from field accesses, e.g. `evt.Record_ID__c` becomes `action.Record_ID`.
+
 ### RFLIB 11.0.0
 
 Package ID: 04tKY0000005RZ5YAM

--- a/rflib-tf/main/default/classes/rflib_RetryableAction.cls
+++ b/rflib-tf/main/default/classes/rflib_RetryableAction.cls
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Johannes Fischer <fischer.jh@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name "RFLIB", the name of the copyright holder, nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * @group RetryableAction
+ * @description Read-only data object representing a single Retryable Action. It carries the custom and
+ *              standard fields of the `rflib_Retryable_Action__e` and `rflib_Retryable_Action_After_Commit__e`
+ *              Platform Events, decoupling handler implementations from the concrete event type. Property
+ *              names match the event field API names; Apex does not allow consecutive underscores in
+ *              identifiers, so the `__c` suffix is omitted for custom fields.
+ */
+@SuppressWarnings('PMD.ClassNamingConventions,PMD.PropertyNamingConventions,PMD.FieldNamingConventions')
+public inherited sharing class rflib_RetryableAction {
+
+    public String Action { get; private set; }
+    public String Record_ID { get; private set; }
+    public String Additional_Record_ID { get; private set; }
+    public String Additional_Details { get; private set; }
+    public String ReplayId { get; private set; }
+    public String EventUuid { get; private set; }
+    public SObject event { get; private set; }
+
+    public rflib_RetryableAction(SObject evt) {
+        this.Action = (String) evt.get('Action__c');
+        this.Record_ID = (String) evt.get('Record_ID__c');
+        this.Additional_Record_ID = (String) evt.get('Additional_Record_ID__c');
+        this.Additional_Details = (String) evt.get('Additional_Details__c');
+        this.ReplayId = (String) evt.get('ReplayId');
+        this.EventUuid = (String) evt.get('EventUuid');
+        this.event = evt;
+    }
+
+    public static List<rflib_RetryableAction> fromEvents(List<SObject> events) {
+        List<rflib_RetryableAction> result = new List<rflib_RetryableAction>();
+        for (SObject evt : events) {
+            result.add(new rflib_RetryableAction(evt));
+        }
+        return result;
+    }
+}

--- a/rflib-tf/main/default/classes/rflib_RetryableAction.cls-meta.xml
+++ b/rflib-tf/main/default/classes/rflib_RetryableAction.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rflib-tf/main/default/classes/rflib_RetryableActionHandler.cls
+++ b/rflib-tf/main/default/classes/rflib_RetryableActionHandler.cls
@@ -34,8 +34,8 @@
 public interface rflib_RetryableActionHandler {
 
     /**
-     * Method to be invoked by the Retryable Action Framework when an Action Platform Event is executed in the main event context. 
-     * @param  actions The rflib_Retryable_Action__e object containing all action details.
+     * Method to be invoked by the Retryable Action Framework when an Action Platform Event is executed in the main event context.
+     * @param  actions The rflib_RetryableAction objects containing all action details, including the source Platform Event record.
      */
-    void execute(List<rflib_Retryable_Action__e> actions);
+    void execute(List<rflib_RetryableAction> actions);
 }

--- a/rflib-tf/main/default/classes/rflib_RetryableActionManager.cls
+++ b/rflib-tf/main/default/classes/rflib_RetryableActionManager.cls
@@ -41,10 +41,11 @@ public inherited sharing class rflib_RetryableActionManager {
     private static List<rflib_Retryable_Action_Config__mdt> ALL_CONFIG_VALUES = rflib_Retryable_Action_Config__mdt.getAll().values();
 
     /**
-     * This is the dispatch function that is invoked from the Retryable Action trigger.
-     * @param  List<rflib_Retryable_Action__e> List of events to be processed.
+     * This is the dispatch function that is invoked from the Retryable Action triggers. It supports
+     * both the `rflib_Retryable_Action__e` and the `rflib_Retryable_Action_After_Commit__e` events.
+     * @param  List<SObject> List of Retryable Action events to be processed.
      */
-    public static void dispatch(List<rflib_Retryable_Action__e> events) {
+    public static void dispatch(List<SObject> events) {
         LOGGER.info('Dispatching actions: ' + events);
 
         if (rflib_FeatureSwitch.isTurnedOn('rflib_Disable_All_Retryable_Actions')) {
@@ -52,19 +53,19 @@ public inherited sharing class rflib_RetryableActionManager {
             return;
         }
 
-        Map<String, List<rflib_Retryable_Action__e>> actionsByName = new Map<String, List<rflib_Retryable_Action__e>> (); 
-        for (rflib_Retryable_Action__e evt : events) {
-            if (!actionsByName.containsKey(evt.Action__c)) {
-                actionsByName.put(evt.Action__c, new List<rflib_Retryable_Action__e>());
+        Map<String, List<rflib_RetryableAction>> actionsByName = new Map<String, List<rflib_RetryableAction>> ();
+        for (rflib_RetryableAction action : rflib_RetryableAction.fromEvents(events)) {
+            if (!actionsByName.containsKey(action.Action)) {
+                actionsByName.put(action.Action, new List<rflib_RetryableAction>());
             }
 
-            actionsByName.get(evt.Action__c).add(evt);
+            actionsByName.get(action.Action).add(action);
         }
 
         dispatch(actionsByName);
     }
-    
-    public static void dispatch(Map<String, List<rflib_Retryable_Action__e>> actionsByName) {
+
+    public static void dispatch(Map<String, List<rflib_RetryableAction>> actionsByName) {
         LOGGER.info('Dispatching actions by name: ' + actionsByName);
 
         Map<String, List<RetryableActionHandlerInfo>> handlersByName = getHandlers(actionsByName.keySet());
@@ -72,12 +73,12 @@ public inherited sharing class rflib_RetryableActionManager {
         runHandlers(actionsByName, handlersByName);
     }
 
-    private static void runHandlers(Map<String, List<rflib_Retryable_Action__e>> actionsByName, Map<String, List<RetryableActionHandlerInfo>> handlersByName) {
+    private static void runHandlers(Map<String, List<rflib_RetryableAction>> actionsByName, Map<String, List<RetryableActionHandlerInfo>> handlersByName) {
         for (String actionName : handlersByName.keySet()) {
 
             for (RetryableActionHandlerInfo handlerInfo : handlersByName.get(actionName)) {
                 rflib_RetryableActionHandler handler = handlerInfo.handler;
-                List<rflib_Retryable_Action__e> actions = actionsByName.get(actionName);
+                List<rflib_RetryableAction> actions = actionsByName.get(actionName);
 
                 try {
                     LOGGER.debug('Executing handler {0} with events: {1}', new Object[] { handlerInfo.handlerType.getName(), actions } );

--- a/rflib-tf/main/default/objects/rflib_Retryable_Action_After_Commit__e/fields/Action__c.field-meta.xml
+++ b/rflib-tf/main/default/objects/rflib_Retryable_Action_After_Commit__e/fields/Action__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Action__c</fullName>
+    <description>The action for which the handlers should be executed.</description>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Action</label>
+    <length>255</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/rflib-tf/main/default/objects/rflib_Retryable_Action_After_Commit__e/fields/Additional_Details__c.field-meta.xml
+++ b/rflib-tf/main/default/objects/rflib_Retryable_Action_After_Commit__e/fields/Additional_Details__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Additional_Details__c</fullName>
+    <description>Additional details that can be provided to help with the execution. I.e. a serialized SObject.</description>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Additional Details</label>
+    <length>32768</length>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/rflib-tf/main/default/objects/rflib_Retryable_Action_After_Commit__e/fields/Additional_Record_ID__c.field-meta.xml
+++ b/rflib-tf/main/default/objects/rflib_Retryable_Action_After_Commit__e/fields/Additional_Record_ID__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Additional_Record_ID__c</fullName>
+    <description>A record ID that is associated with the action, linked to the main record ID, i.e. an Account for a Contact.</description>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Additional Record ID</label>
+    <length>18</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/rflib-tf/main/default/objects/rflib_Retryable_Action_After_Commit__e/fields/Record_ID__c.field-meta.xml
+++ b/rflib-tf/main/default/objects/rflib_Retryable_Action_After_Commit__e/fields/Record_ID__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Record_ID__c</fullName>
+    <description>The main record ID associated with this action.</description>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Record ID</label>
+    <length>18</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/rflib-tf/main/default/objects/rflib_Retryable_Action_After_Commit__e/rflib_Retryable_Action_After_Commit__e.object-meta.xml
+++ b/rflib-tf/main/default/objects/rflib_Retryable_Action_After_Commit__e/rflib_Retryable_Action_After_Commit__e.object-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Platform Event to trigger an action implementation that can be run multiple times before failing. Unlike the Retryable Action event, this event is published after the transaction is committed. See https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_events_subscribe_apex_refire.htm for details.</description>
+    <eventType>HighVolume</eventType>
+    <label>Retryable Action After Commit</label>
+    <pluralLabel>Retryable Actions After Commit</pluralLabel>
+    <publishBehavior>PublishAfterCommit</publishBehavior>
+</CustomObject>

--- a/rflib-tf/main/default/triggers/rflib_RetryableActionAfterCommitTrigger.trigger
+++ b/rflib-tf/main/default/triggers/rflib_RetryableActionAfterCommitTrigger.trigger
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Johannes Fischer <fischer.jh@gmail.com>
+ * Copyright (c) 2026 Johannes Fischer <fischer.jh@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,29 +26,6 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-@IsTest
-@SuppressWarnings('PMD.ClassNamingConventions')
-public class rflib_MockRetryableActionHandler implements rflib_RetryableActionHandler {
-    
-    private static final rflib_Logger LOGGER = new rflib_DefaultLoggerFactory().createLogger('rflib_MockRetryableActionHandler');
-
-    public static List<rflib_RetryableAction> CAPTURED_ACTION_EVENTS = new List<rflib_RetryableAction>();
-
-    public static Exception EXCEPTION_ON_EXECUTE = null;
-    public static Callable ACTION_WHEN_CALLED = null;
-
-    public void execute(List<rflib_RetryableAction> actions) {
-        LOGGER.info('run() invoked');
-
-        CAPTURED_ACTION_EVENTS.addAll(actions);
-
-        LOGGER.info('will run action={0}, should throw exception={1} ', new object[] { (ACTION_WHEN_CALLED != null), (EXCEPTION_ON_EXECUTE != null) });
-        if (ACTION_WHEN_CALLED != null) {
-            ACTION_WHEN_CALLED.call('run', new Map<String, Object> { 'actions' => actions });
-        }
-
-        if (EXCEPTION_ON_EXECUTE != null) {
-            throw EXCEPTION_ON_EXECUTE;
-        }
-    }
+trigger rflib_RetryableActionAfterCommitTrigger on rflib_Retryable_Action_After_Commit__e (after insert) {
+    rflib_RetryableActionManager.dispatch(Trigger.new);
 }

--- a/rflib-tf/main/default/triggers/rflib_RetryableActionAfterCommitTrigger.trigger-meta.xml
+++ b/rflib-tf/main/default/triggers/rflib_RetryableActionAfterCommitTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>

--- a/rflib-tf/test/default/classes/rflib_RetryableActionManagerTest.cls
+++ b/rflib-tf/test/default/classes/rflib_RetryableActionManagerTest.cls
@@ -85,8 +85,46 @@ private class rflib_RetryableActionManagerTest {
         Test.stopTest();
 
         Assert.areEqual(2, rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.size());
-        Assert.areEqual('recId1', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0).Record_ID__c);
-        Assert.areEqual('recId3', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(1).Record_ID__c);
+        Assert.areEqual('recId1', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0).Record_ID);
+        Assert.areEqual('recId3', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(1).Record_ID);
+    }
+
+    @IsTest
+    public static void testExecute_OneHandler_AfterCommitEvents() {
+        setup();
+
+        List<rflib_Retryable_Action_After_Commit__e> events = createAfterCommitEvents();
+
+        Test.startTest();
+        rflib_RetryableActionManager.dispatch(events);
+        Test.stopTest();
+
+        Assert.areEqual(2, rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.size());
+        Assert.areEqual('recId1', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0).Record_ID);
+        Assert.areEqual('recId3', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(1).Record_ID);
+        Assert.isInstanceOfType(rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0).event, rflib_Retryable_Action_After_Commit__e.class);
+    }
+
+    @IsTest
+    public static void testExecute_AfterCommitEventDeliveredThroughEventBus() {
+        setup();
+
+        Test.startTest();
+        EventBus.publish(new rflib_Retryable_Action_After_Commit__e(
+            Record_ID__c = 'recId1',
+            Action__c = 'Action_One'
+        ));
+        Test.getEventBus().deliver();
+        Test.stopTest();
+
+        Assert.areEqual(1, rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.size());
+
+        rflib_RetryableAction action = rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0);
+        Assert.areEqual('Action_One', action.Action);
+        Assert.areEqual('recId1', action.Record_ID);
+        Assert.isNotNull(action.ReplayId);
+        Assert.isNotNull(action.EventUuid);
+        Assert.isInstanceOfType(action.event, rflib_Retryable_Action_After_Commit__e.class);
     }
 
     @IsTest
@@ -106,10 +144,10 @@ private class rflib_RetryableActionManagerTest {
 
         // It would be expected that each handler is a different class, but the test scenario was simplified with a single mock.
         Assert.areEqual(4, rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.size());
-        Assert.areEqual('recId1', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0).Record_ID__c);
-        Assert.areEqual('recId3', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(1).Record_ID__c);
-        Assert.areEqual('recId1', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(2).Record_ID__c);
-        Assert.areEqual('recId3', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(3).Record_ID__c);
+        Assert.areEqual('recId1', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0).Record_ID);
+        Assert.areEqual('recId3', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(1).Record_ID);
+        Assert.areEqual('recId1', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(2).Record_ID);
+        Assert.areEqual('recId3', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(3).Record_ID);
     }
 
     @IsTest
@@ -128,7 +166,7 @@ private class rflib_RetryableActionManagerTest {
         Test.stopTest();
 
         Assert.areEqual(1, rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.size());
-        Assert.areEqual('recId2', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0).Record_ID__c);
+        Assert.areEqual('recId2', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0).Record_ID);
     }
 
     @IsTest
@@ -149,8 +187,28 @@ private class rflib_RetryableActionManagerTest {
         Test.stopTest();
 
         Assert.areEqual(2, rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.size());
-        Assert.areEqual('recId1', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0).Record_ID__c);
-        Assert.areEqual('recId3', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(1).Record_ID__c);
+        Assert.areEqual('recId1', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(0).Record_ID);
+        Assert.areEqual('recId3', rflib_MockRetryableActionHandler.CAPTURED_ACTION_EVENTS.get(1).Record_ID);
+    }
+
+    @IsTest
+    public static void testRetryableActionConfigurationWrapper_CompareTo() {
+        setup();
+
+        rflib_RetryableActionManager.RetryableActionConfigurationWrapper firstOrder = new rflib_RetryableActionManager.RetryableActionConfigurationWrapper(createConfiguration('Action_One', 1));
+        rflib_RetryableActionManager.RetryableActionConfigurationWrapper secondOrder = new rflib_RetryableActionManager.RetryableActionConfigurationWrapper(createConfiguration('Action_One', 2));
+        rflib_RetryableActionManager.RetryableActionConfigurationWrapper nullOrder = new rflib_RetryableActionManager.RetryableActionConfigurationWrapper(createConfiguration('Action_One', null));
+        rflib_RetryableActionManager.RetryableActionConfigurationWrapper nullConfig = new rflib_RetryableActionManager.RetryableActionConfigurationWrapper(null);
+
+        Assert.areEqual(1, firstOrder.compareTo(null));
+        Assert.areEqual(0, nullConfig.compareTo(new rflib_RetryableActionManager.RetryableActionConfigurationWrapper(null)));
+        Assert.areEqual(-1, nullConfig.compareTo(firstOrder));
+        Assert.areEqual(1, firstOrder.compareTo(nullConfig));
+        Assert.areEqual(-1, firstOrder.compareTo(secondOrder));
+        Assert.areEqual(1, secondOrder.compareTo(firstOrder));
+        Assert.areEqual(0, firstOrder.compareTo(firstOrder));
+        Assert.areEqual(-1, nullOrder.compareTo(firstOrder));
+        Assert.areEqual(1, firstOrder.compareTo(nullOrder));
     }
 
     private static List<rflib_Retryable_Action__e> createEvents() {
@@ -164,6 +222,23 @@ private class rflib_RetryableActionManagerTest {
                 Action__c = 'Action_Two'
             ),
             new rflib_Retryable_Action__e(
+                Record_ID__c = 'recId3',
+                Action__c = 'Action_One'
+            )
+        };
+    }
+
+    private static List<rflib_Retryable_Action_After_Commit__e> createAfterCommitEvents() {
+        return new List<rflib_Retryable_Action_After_Commit__e> {
+            new rflib_Retryable_Action_After_Commit__e(
+                Record_ID__c = 'recId1',
+                Action__c = 'Action_One'
+            ),
+            new rflib_Retryable_Action_After_Commit__e(
+                Record_ID__c = 'recId2',
+                Action__c = 'Action_Two'
+            ),
+            new rflib_Retryable_Action_After_Commit__e(
                 Record_ID__c = 'recId3',
                 Action__c = 'Action_One'
             )

--- a/rflib-tf/test/default/classes/rflib_RetryableActionTest.cls
+++ b/rflib-tf/test/default/classes/rflib_RetryableActionTest.cls
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Johannes Fischer <fischer.jh@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name "RFLIB", the name of the copyright holder, nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+@IsTest
+@SuppressWarnings('PMD.ClassNamingConventions')
+private class rflib_RetryableActionTest {
+
+    @IsTest
+    public static void testConstructor_RetryableActionEvent() {
+        rflib_Retryable_Action__e evt = new rflib_Retryable_Action__e(
+            Action__c = 'Action_One',
+            Record_ID__c = 'recId1',
+            Additional_Record_ID__c = 'recId2',
+            Additional_Details__c = 'some details'
+        );
+
+        rflib_RetryableAction action = new rflib_RetryableAction(evt);
+
+        Assert.areEqual('Action_One', action.Action);
+        Assert.areEqual('recId1', action.Record_ID);
+        Assert.areEqual('recId2', action.Additional_Record_ID);
+        Assert.areEqual('some details', action.Additional_Details);
+        Assert.isNull(action.ReplayId);
+        Assert.isNull(action.EventUuid);
+        Assert.areEqual(evt, action.event);
+    }
+
+    @IsTest
+    public static void testConstructor_RetryableActionAfterCommitEvent() {
+        rflib_Retryable_Action_After_Commit__e evt = new rflib_Retryable_Action_After_Commit__e(
+            Action__c = 'Action_Two',
+            Record_ID__c = 'recId3',
+            Additional_Record_ID__c = 'recId4',
+            Additional_Details__c = 'more details'
+        );
+
+        rflib_RetryableAction action = new rflib_RetryableAction(evt);
+
+        Assert.areEqual('Action_Two', action.Action);
+        Assert.areEqual('recId3', action.Record_ID);
+        Assert.areEqual('recId4', action.Additional_Record_ID);
+        Assert.areEqual('more details', action.Additional_Details);
+        Assert.areEqual(evt, action.event);
+    }
+
+    @IsTest
+    public static void testFromEvents() {
+        List<SObject> events = new List<SObject> {
+            new rflib_Retryable_Action__e(
+                Action__c = 'Action_One',
+                Record_ID__c = 'recId1'
+            ),
+            new rflib_Retryable_Action_After_Commit__e(
+                Action__c = 'Action_Two',
+                Record_ID__c = 'recId2'
+            )
+        };
+
+        List<rflib_RetryableAction> actions = rflib_RetryableAction.fromEvents(events);
+
+        Assert.areEqual(2, actions.size());
+        Assert.areEqual('recId1', actions.get(0).Record_ID);
+        Assert.isInstanceOfType(actions.get(0).event, rflib_Retryable_Action__e.class);
+        Assert.areEqual('recId2', actions.get(1).Record_ID);
+        Assert.isInstanceOfType(actions.get(1).event, rflib_Retryable_Action_After_Commit__e.class);
+    }
+}

--- a/rflib-tf/test/default/classes/rflib_RetryableActionTest.cls-meta.xml
+++ b/rflib-tf/test/default/classes/rflib_RetryableActionTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
## What

- Adds the `rflib_Retryable_Action_After_Commit__e` Platform Event — identical fields to `rflib_Retryable_Action__e`, but with **Publish After Commit** behavior — plus a delegating `rflib_RetryableActionAfterCommitTrigger`.
- **BREAKING:** `rflib_RetryableActionHandler.execute()` now takes a `List<rflib_RetryableAction>` instead of `List<rflib_Retryable_Action__e>`. The new read-only `rflib_RetryableAction` data object works for both events and exposes the custom fields as properties named after the field API names without the `__c` suffix (`Action`, `Record_ID`, `Additional_Record_ID`, `Additional_Details`), the standard `ReplayId`/`EventUuid` fields, and the raw event record via `event`.
- `rflib_RetryableActionManager` now dispatches both events through one shared pipeline (same `rflib_Retryable_Action_Config__mdt` configuration, `rflib_Disable_All_Retryable_Actions` feature switch, and retry behavior).

## Why

Salesforce fixes publish behavior per event *definition*, not per publish call. A customer's subscriber logic failed because `rflib_Retryable_Action__e` (Publish Immediately) delivered events before the publishing transaction committed, so record lookups in the handler could not see the source records. Editing the event in the subscriber org is not durable — package upgrades revert modifications to package-owned metadata — so the framework now ships both timing variants and publishers choose by event. The original event keeps Publish Immediately semantics for existing subscribers.

The DTO-based handler signature is a deliberate one-time break: future event variants or new fields will never require another interface change, and handlers keep access to `ReplayId`/`EventUuid`, which an in-memory conversion to the old event type would have lost.

## Migration (for handler implementations)

Change the `execute()` parameter type and drop the `__c` suffix from field access, e.g. `evt.Record_ID__c` → `action.Record_ID` (or use `action.event` for the raw record). Apex forbids consecutive underscores in identifiers, which is why the `__c` suffix is omitted from the property names.

## Reviewer notes

- Validated on a scratch org: full `gulp test` suite green (801 Apex tests, 93% org-wide coverage, lint/flow scan clean, 232 LWC tests) and all 46 Playwright E2E specs pass.
- `rflib_RetryableActionManager` coverage is 98% (only the retry-count warn/fatal branches remain, which are unreachable without real platform-event retries); `rflib_RetryableAction` and the new trigger are at 100%.
- An event-bus delivery test (`testExecute_AfterCommitEventDeliveredThroughEventBus`) asserts `ReplayId`/`EventUuid` are populated end-to-end; an ad-hoc org check confirmed the new trigger consumes published events (`EventBusSubscriber` position advanced, no error).
- Not included (manual follow-ups): RFLIB-TF 4.0.0 package creation + CHANGELOG package details, and the Retryable Actions wiki page update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)